### PR TITLE
Framework as Singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ public:
 
 int main(int argc, char **argv)
 {
-    af::initialize(); // initialize all things AllegroFlare
-    Display *display = af::create_display(800, 600); // creates a new Window
+    Framework::initialize(); // initialize all things AllegroFlare
+    Display *display = Framework::create_display(800, 600); // creates a new Window
     MyApp *my_app = new MyApp(display); // creates a new instance of your app
-    af::run_loop(); // run the AllegroFlare framework
+    Framework::run_loop(); // run the AllegroFlare framework
 }
 ```
 
@@ -71,10 +71,10 @@ Some Examples of Features and Tools
 -----------------------------------
 
 ### Framework
-- Initialize (basically) everything with one function (`af::initialize()`)
+- Initialize (basically) everything with one function (`Framework::initialize()`)
 - Interface with the system through a parent class (`Screen`)
 - Use virtual member functions to grab events (`primary_timer_func()`, `mouse_axes_func()`, `joy_button_down_func()`, `key_char_func()`, etc)
-- Access assets through global media bins (`af::bitmaps["mypic.jpg"]`, `af::fonts["Times.ttf 16"]`, etc)
+- Access assets through global media bins (`Framework::bitmaps["mypic.jpg"]`, `Framework::fonts["Times.ttf 16"]`, etc)
 
 ### Resource Management
 - Bins for media files (`FontBin`, `SampleBin`, `BitmapBin`)
@@ -151,10 +151,10 @@ public:
 
 void main()
 {
-	af::initialize();
-	Display *display = af::create_display(800, 600, NULL);
+	Framework::initialize();
+	Display *display = Framework::create_display(800, 600, NULL);
 	Project *project = new Project(display);
-	af::run_loop();
+	Framework::run_loop();
 }
 ```
 

--- a/examples/demo_ray_casting.cpp
+++ b/examples/demo_ray_casting.cpp
@@ -1311,7 +1311,7 @@ public:
 				{
 					text_notification.set_text("Press 'R' to reload");
 					text_notification.spawn();
-					motion.canimate(&gun_sprite.get_attr("y"), display->height()+8, display->height(), af::time_now, af::time_now+0.1, interpolator::doubleFastIn, NULL, NULL);  
+					motion.canimate(&gun_sprite.get_attr("y"), display->height()+8, display->height(), Framework::time_now, Framework::time_now+0.1, interpolator::doubleFastIn, NULL, NULL);  
 				}
 			}
 			else
@@ -1320,7 +1320,7 @@ public:
 				al_play_sample(samples["gunshot-01.wav"], 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
 				bullets_in_magazine--;
 				gun_fired = true;
-				motion.canimate(&gun_sprite.get_attr("y"), display->height()-16, display->height(), af::time_now, af::time_now+0.2, interpolator::doubleFastIn, NULL, NULL);  
+				motion.canimate(&gun_sprite.get_attr("y"), display->height()-16, display->height(), Framework::time_now, Framework::time_now+0.2, interpolator::doubleFastIn, NULL, NULL);  
 			}
 		}
 	}
@@ -1331,7 +1331,7 @@ public:
 
 
 	  profiler.start("motion.update()");
-		motion.update(af::time_now);
+		motion.update(Framework::time_now);
 	  profiler.stop("motion.update()");
 
 
@@ -1857,7 +1857,7 @@ public:
 					  if (player_picked_up_item)
 					  {
 						  depth_caches_z_sorted[x]->obj_entity->active = false;
-						  animate_color(&motion, &frame_color, item_color, color::black, af::time_now, pickup_frame_time_length, interpolator::fastIn);
+						  animate_color(&motion, &frame_color, item_color, color::black, Framework::time_now, pickup_frame_time_length, interpolator::fastIn);
 						  text_notification.set_text(notification_text, TextNotification::STYLE_PICKUP_ITEM);
 						  text_notification.background_color = item_color;
 						  text_notification.spawn();
@@ -1872,7 +1872,7 @@ public:
 	}
 	void key_down_func() override
 	{
-		switch(af::current_event->keyboard.keycode)
+		switch(Framework::current_event->keyboard.keycode)
 		{
 		case ALLEGRO_KEY_F1:
 			debug = !debug;
@@ -1889,7 +1889,7 @@ public:
 	}
 	void key_up_func() override
 	{
-		switch(af::current_event->keyboard.keycode)
+		switch(Framework::current_event->keyboard.keycode)
 		{
 			case ALLEGRO_KEY_SPACE:
 				trigger_down = false;
@@ -1909,10 +1909,10 @@ public:
 	}
 	void mouse_axes_func() override
 	{
-		int dx = af::current_event->mouse.dx;
+		int dx = Framework::current_event->mouse.dx;
 		if (abs(dx) > 0)
 		{
-			double rotSpeed = af::current_event->mouse.dx * 0.001;
+			double rotSpeed = Framework::current_event->mouse.dx * 0.001;
 			rotate_view(rotSpeed);
 		}
 	}
@@ -1922,10 +1922,10 @@ public:
 
 int main(int argc, char *argv[])
 {
-	af::initialize();
-	Display *display = af::create_display(1920/2, 1080/2);
+	Framework::initialize();
+	Display *display = Framework::create_display(1920/2, 1080/2);
 	Project *project = new Project(display);
-	af::run_loop();
+	Framework::run_loop();
 	return 0;
 }
 

--- a/examples/ex_blur.cpp
+++ b/examples/ex_blur.cpp
@@ -19,7 +19,7 @@ public:
 		, blurred(NULL)
 		, src(NULL)
 	{
-		ALLEGRO_BITMAP *src = af::bitmaps["elm_circle.png"];
+		ALLEGRO_BITMAP *src = Framework::bitmaps["elm_circle.png"];
 		blurred = al_create_bitmap(al_get_bitmap_width(src), al_get_bitmap_height(src));
 	}
 	void key_down_func() override
@@ -29,7 +29,7 @@ public:
 		algo = algo % 4;
 
 		al_destroy_bitmap(src);
-		src = al_clone_bitmap(af::bitmaps["elm_circle.png"]);
+		src = al_clone_bitmap(Framework::bitmaps["elm_circle.png"]);
 
 		switch(algo)
 		{
@@ -50,10 +50,10 @@ public:
 	void primary_timer_func() override
 	{
 		int h=al_get_bitmap_height(blurred), w=al_get_bitmap_width(blurred);
-		al_draw_bitmap(af::bitmaps["elm_circle.png"], display->width()/2-w/2-w/2, display->height()/2-h/2, 0);
+		al_draw_bitmap(Framework::bitmaps["elm_circle.png"], display->width()/2-w/2-w/2, display->height()/2-h/2, 0);
 		al_draw_bitmap(blurred, display->width()/2-w/2+w/2, display->height()/2-h/2, 0);
 
-		al_draw_text(af::fonts["DroidSans.ttf 20"], color::white, 100, 100, 0, "Press any key to cycle through the blending modes");
+		al_draw_text(Framework::fonts["DroidSans.ttf 20"], color::white, 100, 100, 0, "Press any key to cycle through the blending modes");
 	}
 };
 
@@ -61,10 +61,10 @@ public:
 
 int main(int argc, char **argv)
 {
-	af::initialize();
-	Display *display = af::create_display();
+	Framework::initialize();
+	Display *display = Framework::create_display();
 	MyProject *proj = new MyProject(display);
-	af::run_loop();
+	Framework::run_loop();
 
 	return 0;
 }

--- a/examples/ex_blur.cpp
+++ b/examples/ex_blur.cpp
@@ -19,7 +19,7 @@ public:
 		, blurred(NULL)
 		, src(NULL)
 	{
-		ALLEGRO_BITMAP *src = Framework::bitmaps["elm_circle.png"];
+		ALLEGRO_BITMAP *src = Framework::bitmap("elm_circle.png");
 		blurred = al_create_bitmap(al_get_bitmap_width(src), al_get_bitmap_height(src));
 	}
 	void key_down_func() override
@@ -29,7 +29,7 @@ public:
 		algo = algo % 4;
 
 		al_destroy_bitmap(src);
-		src = al_clone_bitmap(Framework::bitmaps["elm_circle.png"]);
+		src = al_clone_bitmap(Framework::bitmap("elm_circle.png"));
 
 		switch(algo)
 		{
@@ -50,10 +50,10 @@ public:
 	void primary_timer_func() override
 	{
 		int h=al_get_bitmap_height(blurred), w=al_get_bitmap_width(blurred);
-		al_draw_bitmap(Framework::bitmaps["elm_circle.png"], display->width()/2-w/2-w/2, display->height()/2-h/2, 0);
+		al_draw_bitmap(Framework::bitmap("elm_circle.png"), display->width()/2-w/2-w/2, display->height()/2-h/2, 0);
 		al_draw_bitmap(blurred, display->width()/2-w/2+w/2, display->height()/2-h/2, 0);
 
-		al_draw_text(Framework::fonts["DroidSans.ttf 20"], color::white, 100, 100, 0, "Press any key to cycle through the blending modes");
+		al_draw_text(Framework::font("DroidSans.ttf 20"), color::white, 100, 100, 0, "Press any key to cycle through the blending modes");
 	}
 };
 

--- a/examples/ex_gamer_input.cpp
+++ b/examples/ex_gamer_input.cpp
@@ -41,7 +41,7 @@ public:
 		, simple_notification_screen(NULL)
 	{
 		gamer_input_screen = new GamerInputScreen(display);
-		simple_notification_screen = new SimpleNotificationScreen(display, Framework::fonts["DroidSans.ttf 20"]);
+		simple_notification_screen = new SimpleNotificationScreen(display, Framework::font("DroidSans.ttf 20"));
 	}
 	void primary_timer_func() override
 	{

--- a/examples/ex_gamer_input.cpp
+++ b/examples/ex_gamer_input.cpp
@@ -41,7 +41,7 @@ public:
 		, simple_notification_screen(NULL)
 	{
 		gamer_input_screen = new GamerInputScreen(display);
-		simple_notification_screen = new SimpleNotificationScreen(display, af::fonts["DroidSans.ttf 20"]);
+		simple_notification_screen = new SimpleNotificationScreen(display, Framework::fonts["DroidSans.ttf 20"]);
 	}
 	void primary_timer_func() override
 	{
@@ -58,19 +58,19 @@ public:
 	}
 	void user_event_func() override
 	{
-		switch(af::current_event->type)
+		switch(Framework::current_event->type)
 		{
 		case ALLEGRO_EVENT_GAMER_BUTTON_UP:
-			if (af::current_event->user.data1 == GAMER_BUTTON_UP) moving_up = false;
-			if (af::current_event->user.data1 == GAMER_BUTTON_DOWN) moving_down = false;
-			if (af::current_event->user.data1 == GAMER_BUTTON_LEFT) moving_left = false;
-			if (af::current_event->user.data1 == GAMER_BUTTON_RIGHT) moving_right = false;
+			if (Framework::current_event->user.data1 == GAMER_BUTTON_UP) moving_up = false;
+			if (Framework::current_event->user.data1 == GAMER_BUTTON_DOWN) moving_down = false;
+			if (Framework::current_event->user.data1 == GAMER_BUTTON_LEFT) moving_left = false;
+			if (Framework::current_event->user.data1 == GAMER_BUTTON_RIGHT) moving_right = false;
 			break;
 		case ALLEGRO_EVENT_GAMER_BUTTON_DOWN:
-			if (af::current_event->user.data1 == GAMER_BUTTON_UP) moving_up = true;
-			if (af::current_event->user.data1 == GAMER_BUTTON_DOWN) moving_down = true;
-			if (af::current_event->user.data1 == GAMER_BUTTON_LEFT) moving_left = true;
-			if (af::current_event->user.data1 == GAMER_BUTTON_RIGHT) moving_right = true;
+			if (Framework::current_event->user.data1 == GAMER_BUTTON_UP) moving_up = true;
+			if (Framework::current_event->user.data1 == GAMER_BUTTON_DOWN) moving_down = true;
+			if (Framework::current_event->user.data1 == GAMER_BUTTON_LEFT) moving_left = true;
+			if (Framework::current_event->user.data1 == GAMER_BUTTON_RIGHT) moving_right = true;
 			break;
 		}
 	}
@@ -78,10 +78,10 @@ public:
 	{
 		if (simple_notification_screen)
 		{
-			if (af::joystick != NULL)
+			if (Framework::joystick != NULL)
 			{
 				std::stringstream notification_message;
-				notification_message << "New joystick added\n" << al_get_joystick_name(af::joystick);
+				notification_message << "New joystick added\n" << al_get_joystick_name(Framework::joystick);
 				simple_notification_screen->spawn_notification(notification_message.str());
 			}
 			else
@@ -97,10 +97,10 @@ public:
 
 int main(int argc, char **argv)
 {
-	af::initialize();
-	Display *display = af::create_display();
+	Framework::initialize();
+	Display *display = Framework::create_display();
 	MyProject *proj = new MyProject(display);
-	af::run_loop();
+	Framework::run_loop();
 
 	return 0;
 }

--- a/examples/ex_histogram.cpp
+++ b/examples/ex_histogram.cpp
@@ -11,10 +11,10 @@ public:
 	MyProject(Display *display) : Screen(display) {}
 	void primary_timer_func() override
 	{
-		al_draw_bitmap(af::bitmaps["pun_dog.jpg"], 125, 150, 0);
+		al_draw_bitmap(Framework::bitmaps["pun_dog.jpg"], 125, 150, 0);
 	
 		al_draw_filled_rectangle(750-10-25, 200-10, 1200+10-25, 200+300+10, color::gray);	
-		draw_histogram(af::bitmaps["pun_dog.jpg"], 750-25, 200, 450, 300, color::white);
+		draw_histogram(Framework::bitmaps["pun_dog.jpg"], 750-25, 200, 450, 300, color::white);
 	}
 };
 
@@ -22,10 +22,10 @@ public:
 
 int main(int argc, char **argv)
 {
-	af::initialize();
-	Display *display = af::create_display();
+	Framework::initialize();
+	Display *display = Framework::create_display();
 	MyProject *proj = new MyProject(display);
-	af::run_loop();
+	Framework::run_loop();
 	return 0;
 }
 

--- a/examples/ex_histogram.cpp
+++ b/examples/ex_histogram.cpp
@@ -11,10 +11,10 @@ public:
 	MyProject(Display *display) : Screen(display) {}
 	void primary_timer_func() override
 	{
-		al_draw_bitmap(Framework::bitmaps["pun_dog.jpg"], 125, 150, 0);
+		al_draw_bitmap(Framework::bitmap("pun_dog.jpg"), 125, 150, 0);
 	
 		al_draw_filled_rectangle(750-10-25, 200-10, 1200+10-25, 200+300+10, color::gray);	
-		draw_histogram(Framework::bitmaps["pun_dog.jpg"], 750-25, 200, 450, 300, color::white);
+		draw_histogram(Framework::bitmap("pun_dog.jpg"), 750-25, 200, 450, 300, color::white);
 	}
 };
 

--- a/examples/ex_masked_bitmap.cpp
+++ b/examples/ex_masked_bitmap.cpp
@@ -23,12 +23,12 @@ private:
 public:
 	MaskedBitmapExampleProgram(Display *display) : Screen(display)
 	{
-		bitmap = create_masked_bitmap(Framework::bitmaps["rooster_cat_grid.png"], Framework::bitmaps["elm_circle.png"]);
+		bitmap = create_masked_bitmap(Framework::bitmap("rooster_cat_grid.png"), Framework::bitmap("elm_circle.png"));
 	}
 	void primary_timer_func() override
 	{
-		al_draw_bitmap(Framework::bitmaps["rooster_cat_grid.png"], 100, 100, 0);
-		al_draw_bitmap(Framework::bitmaps["elm_circle.png"], 400, 100, 0);
+		al_draw_bitmap(Framework::bitmap("rooster_cat_grid.png"), 100, 100, 0);
+		al_draw_bitmap(Framework::bitmap("elm_circle.png"), 400, 100, 0);
 		al_draw_bitmap(bitmap, 700, 100, 0);
 	}
 };

--- a/examples/ex_masked_bitmap.cpp
+++ b/examples/ex_masked_bitmap.cpp
@@ -23,12 +23,12 @@ private:
 public:
 	MaskedBitmapExampleProgram(Display *display) : Screen(display)
 	{
-		bitmap = create_masked_bitmap(af::bitmaps["rooster_cat_grid.png"], af::bitmaps["elm_circle.png"]);
+		bitmap = create_masked_bitmap(Framework::bitmaps["rooster_cat_grid.png"], Framework::bitmaps["elm_circle.png"]);
 	}
 	void primary_timer_func() override
 	{
-		al_draw_bitmap(af::bitmaps["rooster_cat_grid.png"], 100, 100, 0);
-		al_draw_bitmap(af::bitmaps["elm_circle.png"], 400, 100, 0);
+		al_draw_bitmap(Framework::bitmaps["rooster_cat_grid.png"], 100, 100, 0);
+		al_draw_bitmap(Framework::bitmaps["elm_circle.png"], 400, 100, 0);
 		al_draw_bitmap(bitmap, 700, 100, 0);
 	}
 };
@@ -36,10 +36,10 @@ public:
 
 int main(int argc, char **argv)
 {
-	af::initialize();
-	Display *display = af::create_display(1100, 500);
+	Framework::initialize();
+	Display *display = Framework::create_display(1100, 500);
 	MaskedBitmapExampleProgram *prog = new MaskedBitmapExampleProgram(display);
-	af::run_loop();
+	Framework::run_loop();
 
 	return 0;
 }

--- a/examples/ex_model_viewer.cpp
+++ b/examples/ex_model_viewer.cpp
@@ -43,12 +43,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-	af::initialize();
-	Display *display = af::create_display(800, 600);
+	Framework::initialize();
+	Display *display = Framework::create_display(800, 600);
 
 	Project *proj = new Project(display);
 
-	af::run_loop();
+	Framework::run_loop();
 
 	return 0;
 }

--- a/examples/ex_unicode_font_viewer.cpp
+++ b/examples/ex_unicode_font_viewer.cpp
@@ -81,7 +81,7 @@ void UnicodeFontViewerExample::primary_timer_func()
 
 void UnicodeFontViewerExample::key_char_func()
 {
-	switch(af::current_event->keyboard.keycode)
+	switch(Framework::current_event->keyboard.keycode)
 	{
 	case ALLEGRO_KEY_RIGHT:
 		unicode_range_start += 0x0100;
@@ -98,10 +98,10 @@ void UnicodeFontViewerExample::key_char_func()
 
 int main(int argc, char **argv)
 {
-	af::initialize();
-	Display *display = af::create_display();
+	Framework::initialize();
+	Display *display = Framework::create_display();
 	UnicodeFontViewerExample *program = new UnicodeFontViewerExample(display, "Bravura.otf 40");
-	af::run_loop();
+	Framework::run_loop();
 	return 0;
 }
 

--- a/examples/gui/dev_automation_controller.cpp
+++ b/examples/gui/dev_automation_controller.cpp
@@ -102,12 +102,12 @@ public:
             al_draw_circle(points[i].x, points[i].y, 10, color::color(color::orange, 0.2), 6);
 
          // draw the debug (for testing)
-         // al_draw_text(af::fonts["DroidSans.ttf 16"], color::white, points[i].x, points[i].y, ALLEGRO_ALIGN_CENTRE, tostring(i).c_str());
+         // al_draw_text(Framework::fonts["DroidSans.ttf 16"], color::white, points[i].x, points[i].y, ALLEGRO_ALIGN_CENTRE, tostring(i).c_str());
       }
    }
    void on_click() override
    {
-      if (af::current_event->mouse.button == 2) // right-click
+      if (Framework::current_event->mouse.button == 2) // right-click
       {
          // erase the focused point
          if (focused_points_index != -1)
@@ -117,7 +117,7 @@ public:
             sort_points();
          }
       }
-      else if (af::current_event->mouse.button == 1) // left-click
+      else if (Framework::current_event->mouse.button == 1) // left-click
       {
          // create a new point on the graph
          points.push_back(mouse_pos);
@@ -146,10 +146,10 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display(1000, 700);
+   Framework::initialize();
+   Display *display = Framework::create_display(1000, 700);
    RubberBandDev *rubber_band_dev = new RubberBandDev(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/gui/dev_clock_widget.cpp
+++ b/examples/gui/dev_clock_widget.cpp
@@ -84,7 +84,7 @@ void draw_clock(float x, float y, float radius=100, float opacity=1.0)
 
    if (true)
    {
-      ALLEGRO_BITMAP *clock_overlay = af::bitmaps["clock_overlay.png"];
+      ALLEGRO_BITMAP *clock_overlay = Framework::bitmaps["clock_overlay.png"];
       float clock_overlay_scale = scale/2;
       al_draw_tinted_scaled_bitmap(clock_overlay, color::name("white", opacity),
          0, 0, al_get_bitmap_width(clock_overlay), al_get_bitmap_height(clock_overlay),
@@ -101,18 +101,18 @@ void draw_clock(float x, float y, float radius=100, float opacity=1.0)
 
 void hide_clock(void *obj, ALLEGRO_MOUSE_EVENT *ev, void *user)
 {
-   af::motion.cmove_to(&clock_opacity, 0.0, 0.6);
-   af::motion.cmove_to(&clock_radius, max_clock_radius*0.9, 0.6);
-   if (clock_opacity == 1.0) al_play_sample(af::samples["clock_hide.wav"], 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
+   Framework::motion.cmove_to(&clock_opacity, 0.0, 0.6);
+   Framework::motion.cmove_to(&clock_radius, max_clock_radius*0.9, 0.6);
+   if (clock_opacity == 1.0) al_play_sample(Framework::samples["clock_hide.wav"], 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
 }
 
 
 
 void show_clock(void *obj, ALLEGRO_MOUSE_EVENT *ev, void *user)
 {
-   af::motion.cmove_to(&clock_opacity, 1.0, 0.3, interpolator::slowInOut);
-   af::motion.cmove_to(&clock_radius, max_clock_radius, 0.3, interpolator::slowInOut);
-   if (clock_opacity == 0.0) al_play_sample(af::samples["clock_show.wav"], 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
+   Framework::motion.cmove_to(&clock_opacity, 1.0, 0.3, interpolator::slowInOut);
+   Framework::motion.cmove_to(&clock_radius, max_clock_radius, 0.3, interpolator::slowInOut);
+   if (clock_opacity == 0.0) al_play_sample(Framework::samples["clock_show.wav"], 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
 }
 
 
@@ -182,10 +182,10 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display();
+   Framework::initialize();
+   Display *display = Framework::create_display();
    ClockExampleProgram *program = new ClockExampleProgram(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/gui/dev_clock_widget.cpp
+++ b/examples/gui/dev_clock_widget.cpp
@@ -84,7 +84,7 @@ void draw_clock(float x, float y, float radius=100, float opacity=1.0)
 
    if (true)
    {
-      ALLEGRO_BITMAP *clock_overlay = Framework::bitmaps["clock_overlay.png"];
+      ALLEGRO_BITMAP *clock_overlay = Framework::bitmap("clock_overlay.png");
       float clock_overlay_scale = scale/2;
       al_draw_tinted_scaled_bitmap(clock_overlay, color::name("white", opacity),
          0, 0, al_get_bitmap_width(clock_overlay), al_get_bitmap_height(clock_overlay),
@@ -101,18 +101,18 @@ void draw_clock(float x, float y, float radius=100, float opacity=1.0)
 
 void hide_clock(void *obj, ALLEGRO_MOUSE_EVENT *ev, void *user)
 {
-   Framework::motion.cmove_to(&clock_opacity, 0.0, 0.6);
-   Framework::motion.cmove_to(&clock_radius, max_clock_radius*0.9, 0.6);
-   if (clock_opacity == 1.0) al_play_sample(Framework::samples["clock_hide.wav"], 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
+   Framework::motion().cmove_to(&clock_opacity, 0.0, 0.6);
+   Framework::motion().cmove_to(&clock_radius, max_clock_radius*0.9, 0.6);
+   if (clock_opacity == 1.0) al_play_sample(Framework::sample("clock_hide.wav"), 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
 }
 
 
 
 void show_clock(void *obj, ALLEGRO_MOUSE_EVENT *ev, void *user)
 {
-   Framework::motion.cmove_to(&clock_opacity, 1.0, 0.3, interpolator::slowInOut);
-   Framework::motion.cmove_to(&clock_radius, max_clock_radius, 0.3, interpolator::slowInOut);
-   if (clock_opacity == 0.0) al_play_sample(Framework::samples["clock_show.wav"], 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
+   Framework::motion().cmove_to(&clock_opacity, 1.0, 0.3, interpolator::slowInOut);
+   Framework::motion().cmove_to(&clock_radius, max_clock_radius, 0.3, interpolator::slowInOut);
+   if (clock_opacity == 0.0) al_play_sample(Framework::sample("clock_show.wav"), 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
 }
 
 

--- a/examples/gui/dev_console.cpp
+++ b/examples/gui/dev_console.cpp
@@ -60,7 +60,7 @@ public:
 
    FGUIConsole(Display *display)
       : FGUIScreen(display)
-      , font(Framework::fonts["DroidSans.ttf 19"])
+      , font(Framework::font("DroidSans.ttf 19"))
       , active(false)
       , visibility_counter(0)
       , toggle_key(ALLEGRO_KEY_TILDE)
@@ -128,15 +128,15 @@ public:
       if (active)
       {
          // hide
-         Framework::motion.canimate(&visibility_counter, visibility_counter, 0, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
-         Framework::motion.canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, -150, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion().canimate(&visibility_counter, visibility_counter, 0, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion().canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, -150, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
          text_input_widget->set_as_unfocused();
       }
       else
       {
          // show
-         Framework::motion.canimate(&visibility_counter, visibility_counter, 1, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
-         Framework::motion.canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, console_height-console_padding, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion().canimate(&visibility_counter, visibility_counter, 1, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion().canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, console_height-console_padding, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
          text_input_widget->set_as_focused();
       }
 

--- a/examples/gui/dev_console.cpp
+++ b/examples/gui/dev_console.cpp
@@ -60,7 +60,7 @@ public:
 
    FGUIConsole(Display *display)
       : FGUIScreen(display)
-      , font(af::fonts["DroidSans.ttf 19"])
+      , font(Framework::fonts["DroidSans.ttf 19"])
       , active(false)
       , visibility_counter(0)
       , toggle_key(ALLEGRO_KEY_TILDE)
@@ -77,13 +77,13 @@ public:
 
    void key_down_func() override
    {
-      if (af::current_event->keyboard.keycode == toggle_key)
+      if (Framework::current_event->keyboard.keycode == toggle_key)
       {
          toggle_visibility();
       }
       else
       {
-         switch(af::current_event->keyboard.keycode)
+         switch(Framework::current_event->keyboard.keycode)
          {
          case ALLEGRO_KEY_UP:
             current_indexed_past_message--;
@@ -128,15 +128,15 @@ public:
       if (active)
       {
          // hide
-         af::motion.canimate(&visibility_counter, visibility_counter, 0, af::time_now, af::time_now+0.2, interpolator::fastIn, NULL, NULL);
-         af::motion.canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, -150, af::time_now, af::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion.canimate(&visibility_counter, visibility_counter, 0, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion.canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, -150, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
          text_input_widget->set_as_unfocused();
       }
       else
       {
          // show
-         af::motion.canimate(&visibility_counter, visibility_counter, 1, af::time_now, af::time_now+0.2, interpolator::fastIn, NULL, NULL);
-         af::motion.canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, console_height-console_padding, af::time_now, af::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion.canimate(&visibility_counter, visibility_counter, 1, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion.canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, console_height-console_padding, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
          text_input_widget->set_as_focused();
       }
 
@@ -178,9 +178,9 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *d = af::create_display(800, 600);
+   Framework::initialize();
+   Display *d = Framework::create_display(800, 600);
    ExampleProject *ex = new ExampleProject(d);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }

--- a/examples/gui/dev_notification_bubble.cpp
+++ b/examples/gui/dev_notification_bubble.cpp
@@ -26,7 +26,7 @@ public:
    FGUINotificationBubble(FGUIWidget *parent, float x, float y, std::string text)
       : FGUIWidget(parent, new FGUISurfaceAreaBox(x, y, 280, 90))
       , text(text)
-      , font(Framework::fonts["DroidSerif.ttf 20"])
+      , font(Framework::font("DroidSerif.ttf 20"))
       , spawn_time(Framework::time_now)
       , lifespan(4.0)
       , paused(false)
@@ -35,7 +35,7 @@ public:
       attr.set(FGUI_ATTR__FGUI_WIDGET_TYPE, "FGUINotificationBubble");
       attr.set("id", "NotificationBubble" + tostring(FGUIWidget::get_num_created_widgets()));
 
-      Framework::motion.cmove_to(&this->opacity, 1.0, 0.5);
+      Framework::motion().cmove_to(&this->opacity, 1.0, 0.5);
 
       this->surface_area->placement.align.x = 1.0;
       this->surface_area->placement.align.y = 1.0;
@@ -43,7 +43,7 @@ public:
 
    ~FGUINotificationBubble()
    {
-      Framework::motion.clear_animations_on(&this->opacity);
+      Framework::motion().clear_animations_on(&this->opacity);
    }
 
    void on_timer()
@@ -53,7 +53,7 @@ public:
       if ((Framework::time_now - spawn_time) > lifespan)
       {
          delete_me = true;
-         Framework::motion.cmove_to(&this->opacity, 0, 0.6);
+         Framework::motion().cmove_to(&this->opacity, 0, 0.6);
       }
    }
 
@@ -62,7 +62,7 @@ public:
       if (delete_me) return;
 
       paused = true;
-      Framework::motion.cmove_to(&this->opacity, 1.0, 0.5);
+      Framework::motion().cmove_to(&this->opacity, 1.0, 0.5);
    }
 
    void on_mouse_leave()

--- a/examples/gui/dev_notification_bubble.cpp
+++ b/examples/gui/dev_notification_bubble.cpp
@@ -26,8 +26,8 @@ public:
    FGUINotificationBubble(FGUIWidget *parent, float x, float y, std::string text)
       : FGUIWidget(parent, new FGUISurfaceAreaBox(x, y, 280, 90))
       , text(text)
-      , font(af::fonts["DroidSerif.ttf 20"])
-      , spawn_time(af::time_now)
+      , font(Framework::fonts["DroidSerif.ttf 20"])
+      , spawn_time(Framework::time_now)
       , lifespan(4.0)
       , paused(false)
       , opacity(0)
@@ -35,7 +35,7 @@ public:
       attr.set(FGUI_ATTR__FGUI_WIDGET_TYPE, "FGUINotificationBubble");
       attr.set("id", "NotificationBubble" + tostring(FGUIWidget::get_num_created_widgets()));
 
-      af::motion.cmove_to(&this->opacity, 1.0, 0.5);
+      Framework::motion.cmove_to(&this->opacity, 1.0, 0.5);
 
       this->surface_area->placement.align.x = 1.0;
       this->surface_area->placement.align.y = 1.0;
@@ -43,17 +43,17 @@ public:
 
    ~FGUINotificationBubble()
    {
-      af::motion.clear_animations_on(&this->opacity);
+      Framework::motion.clear_animations_on(&this->opacity);
    }
 
    void on_timer()
    {
       if (paused || delete_me) return;
 
-      if ((af::time_now - spawn_time) > lifespan)
+      if ((Framework::time_now - spawn_time) > lifespan)
       {
          delete_me = true;
-         af::motion.cmove_to(&this->opacity, 0, 0.6);
+         Framework::motion.cmove_to(&this->opacity, 0, 0.6);
       }
    }
 
@@ -62,7 +62,7 @@ public:
       if (delete_me) return;
 
       paused = true;
-      af::motion.cmove_to(&this->opacity, 1.0, 0.5);
+      Framework::motion.cmove_to(&this->opacity, 1.0, 0.5);
    }
 
    void on_mouse_leave()
@@ -70,7 +70,7 @@ public:
       if (delete_me) return;
 
       paused = false;
-      spawn_time  = af::time_now;
+      spawn_time  = Framework::time_now;
    }
 
    void on_draw()
@@ -135,12 +135,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
-   Display *display = af::create_display(1280, 800, false);
+   Framework::initialize();
+   Display *display = Framework::create_display(1280, 800, false);
 
    NotificationBubbleTestProject *proj = new NotificationBubbleTestProject(display);
 
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/gui/dev_piano_keyboard.cpp
+++ b/examples/gui/dev_piano_keyboard.cpp
@@ -474,12 +474,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
-   Display *display = af::create_display(1280, 800, false);
+   Framework::initialize();
+   Display *display = Framework::create_display(1280, 800, false);
 
    PianoKeyboardExampleProject *project = new PianoKeyboardExampleProject(display);
 
-   af::run_loop();
+   Framework::run_loop();
 
    return 0;
 }

--- a/examples/gui/dev_software_keyboard.cpp
+++ b/examples/gui/dev_software_keyboard.cpp
@@ -250,7 +250,7 @@ public:
 
    void on_draw() override
    {
-      motion_manager.update(af::time_now);
+      motion_manager.update(Framework::time_now);
 
       al_draw_filled_rectangle(0, 0, w, h, color::black);
       al_draw_rounded_rectangle(0, 0, w, h, 4, 4, color::black, 4.0);
@@ -305,7 +305,7 @@ public:
 
    void on_key_char() override
    {
-      int allegro_key = af::current_event->keyboard.keycode;
+      int allegro_key = Framework::current_event->keyboard.keycode;
       for (unsigned i=0; i<43; i++)
          if (key[i].allegro_key_code == allegro_key) key[i].trigger();
    }
@@ -314,7 +314,7 @@ public:
    {
       if (!visible) return;
 
-      int keycode = af::current_event->keyboard.keycode;
+      int keycode = Framework::current_event->keyboard.keycode;
       if (keycode == ALLEGRO_KEY_RSHIFT || keycode == ALLEGRO_KEY_LSHIFT)
          toggle_shift();
    }
@@ -375,9 +375,9 @@ public:
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
-   Display *display = af::create_display(1100, 600);
+   Framework::initialize();
+   Display *display = Framework::create_display(1100, 600);
    SoftKeyboardExample *example = new SoftKeyboardExample(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }

--- a/examples/gui/ex_calculator.cpp
+++ b/examples/gui/ex_calculator.cpp
@@ -214,7 +214,7 @@ public:
       this->draw_focused_outline = false;
 
       // make a nice background image
-      FGUIImage *img = new FGUIImage(this, 0, 0, Framework::bitmaps["veddy_nice.png"]);
+      FGUIImage *img = new FGUIImage(this, 0, 0, Framework::bitmap("veddy_nice.png"));
          img->set_color(color::color(color::white, 0.2));
          img->place.position = vec2d(display->center(), display->middle());
 
@@ -227,11 +227,11 @@ public:
       calculator->place.rotation = 0.1;
 
       // create a nice "reveal" animation
-      Framework::motion.cmove_to(&calculator->place.position.x, display->center(), 0.7);
-      Framework::motion.cmove_to(&calculator->place.position.y, display->middle(), 0.7);
-      Framework::motion.cmove_to(&calculator->place.scale.x, 1.0, 0.9);
-      Framework::motion.cmove_to(&calculator->place.scale.y, 1.0, 0.9);
-      Framework::motion.cmove_to(&calculator->place.rotation, 0, 0.9);
+      Framework::motion().cmove_to(&calculator->place.position.x, display->center(), 0.7);
+      Framework::motion().cmove_to(&calculator->place.position.y, display->middle(), 0.7);
+      Framework::motion().cmove_to(&calculator->place.scale.x, 1.0, 0.9);
+      Framework::motion().cmove_to(&calculator->place.scale.y, 1.0, 0.9);
+      Framework::motion().cmove_to(&calculator->place.rotation, 0, 0.9);
     }
 };
 

--- a/examples/gui/ex_calculator.cpp
+++ b/examples/gui/ex_calculator.cpp
@@ -214,7 +214,7 @@ public:
       this->draw_focused_outline = false;
 
       // make a nice background image
-      FGUIImage *img = new FGUIImage(this, 0, 0, af::bitmaps["veddy_nice.png"]);
+      FGUIImage *img = new FGUIImage(this, 0, 0, Framework::bitmaps["veddy_nice.png"]);
          img->set_color(color::color(color::white, 0.2));
          img->place.position = vec2d(display->center(), display->middle());
 
@@ -227,20 +227,20 @@ public:
       calculator->place.rotation = 0.1;
 
       // create a nice "reveal" animation
-      af::motion.cmove_to(&calculator->place.position.x, display->center(), 0.7);
-      af::motion.cmove_to(&calculator->place.position.y, display->middle(), 0.7);
-      af::motion.cmove_to(&calculator->place.scale.x, 1.0, 0.9);
-      af::motion.cmove_to(&calculator->place.scale.y, 1.0, 0.9);
-      af::motion.cmove_to(&calculator->place.rotation, 0, 0.9);
+      Framework::motion.cmove_to(&calculator->place.position.x, display->center(), 0.7);
+      Framework::motion.cmove_to(&calculator->place.position.y, display->middle(), 0.7);
+      Framework::motion.cmove_to(&calculator->place.scale.x, 1.0, 0.9);
+      Framework::motion.cmove_to(&calculator->place.scale.y, 1.0, 0.9);
+      Framework::motion.cmove_to(&calculator->place.rotation, 0, 0.9);
     }
 };
 
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display(1000, 600);
+   Framework::initialize();
+   Display *display = Framework::create_display(1000, 600);
    Project *project = new Project(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }

--- a/examples/gui/ex_color_picker.cpp
+++ b/examples/gui/ex_color_picker.cpp
@@ -18,7 +18,7 @@ public:
    void on_draw() override
    {
       FGUIWidget::on_draw();
-      ALLEGRO_FONT *font = af::fonts["DroidSans.ttf 12"];
+      ALLEGRO_FONT *font = Framework::fonts["DroidSans.ttf 12"];
       al_draw_text(font, color::white, place.size.x/2, place.size.y/2 - al_get_font_line_height(font)/2, ALLEGRO_ALIGN_CENTER, attr.get("id").c_str());
    }
 };
@@ -305,9 +305,9 @@ public:
       if (sender == button) // click is automatic message to parent for FGUIButton
       {
          // animate the button around randomly when it gets clicked
-         af::motion.cmove_to(&button->place.position.x, random_float(100, 600), 0.4);
-         af::motion.cmove_to(&button->place.position.y, random_float(100, 500), 0.4);
-         af::motion.cmove_to(&button->place.rotation, random_float(-0.4, 0.4), 0.4);
+         Framework::motion.cmove_to(&button->place.position.x, random_float(100, 600), 0.4);
+         Framework::motion.cmove_to(&button->place.position.y, random_float(100, 500), 0.4);
+         Framework::motion.cmove_to(&button->place.rotation, random_float(-0.4, 0.4), 0.4);
       }
    }
 };
@@ -317,10 +317,10 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display();
+   Framework::initialize();
+   Display *display = Framework::create_display();
    MyProject *proj = new MyProject(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/gui/ex_color_picker.cpp
+++ b/examples/gui/ex_color_picker.cpp
@@ -18,7 +18,7 @@ public:
    void on_draw() override
    {
       FGUIWidget::on_draw();
-      ALLEGRO_FONT *font = Framework::fonts["DroidSans.ttf 12"];
+      ALLEGRO_FONT *font = Framework::font("DroidSans.ttf 12");
       al_draw_text(font, color::white, place.size.x/2, place.size.y/2 - al_get_font_line_height(font)/2, ALLEGRO_ALIGN_CENTER, attr.get("id").c_str());
    }
 };
@@ -305,9 +305,9 @@ public:
       if (sender == button) // click is automatic message to parent for FGUIButton
       {
          // animate the button around randomly when it gets clicked
-         Framework::motion.cmove_to(&button->place.position.x, random_float(100, 600), 0.4);
-         Framework::motion.cmove_to(&button->place.position.y, random_float(100, 500), 0.4);
-         Framework::motion.cmove_to(&button->place.rotation, random_float(-0.4, 0.4), 0.4);
+         Framework::motion().cmove_to(&button->place.position.x, random_float(100, 600), 0.4);
+         Framework::motion().cmove_to(&button->place.position.y, random_float(100, 500), 0.4);
+         Framework::motion().cmove_to(&button->place.rotation, random_float(-0.4, 0.4), 0.4);
       }
    }
 };

--- a/examples/gui/ex_flare_gui.cpp
+++ b/examples/gui/ex_flare_gui.cpp
@@ -30,7 +30,7 @@ public:
    {}
    void on_draw() override
    {
-      ALLEGRO_FONT *font = Framework::fonts["FontAwesome.otf -" + tostring(place.size.x/3)];
+      ALLEGRO_FONT *font = Framework::font("FontAwesome.otf -" + tostring(place.size.x/3));
       int line_height = al_get_font_line_height(font);
       draw_unicode_char(font, color::white, icon, ALLEGRO_ALIGN_CENTER, place.size.x/2, place.size.y/2 - line_height/2-1);
    }
@@ -57,7 +57,7 @@ public:
    MyMediaPlayer(FGUIWidget *parent)
       : FGUIWindow(parent, 650, 500, 200, 170)
       , filename("water_4.wav")
-      , sound(Framework::samples[filename])
+      , sound(Framework::sample(filename))
       , progress_bar(NULL)
       , play_button(NULL)
       , stop_button(NULL)
@@ -253,13 +253,13 @@ public:
       }
       else if (message_caught = (message == "shrink"))
       {
-         Framework::motion.cmove_to(&place.scale.x, 0.86, 0.3);
-         Framework::motion.cmove_to(&place.scale.y, 0.86, 0.3);
+         Framework::motion().cmove_to(&place.scale.x, 0.86, 0.3);
+         Framework::motion().cmove_to(&place.scale.y, 0.86, 0.3);
       }
       else if (message_caught = (message == "grow"))
       {
-         Framework::motion.cmove_to(&place.scale.x, 1, 0.3);
-         Framework::motion.cmove_to(&place.scale.y, 1, 0.3);
+         Framework::motion().cmove_to(&place.scale.x, 1, 0.3);
+         Framework::motion().cmove_to(&place.scale.y, 1, 0.3);
       }
       else if (message_caught = (message == "exit"))
       {

--- a/examples/gui/ex_flare_gui.cpp
+++ b/examples/gui/ex_flare_gui.cpp
@@ -30,7 +30,7 @@ public:
    {}
    void on_draw() override
    {
-      ALLEGRO_FONT *font = af::fonts["FontAwesome.otf -" + tostring(place.size.x/3)];
+      ALLEGRO_FONT *font = Framework::fonts["FontAwesome.otf -" + tostring(place.size.x/3)];
       int line_height = al_get_font_line_height(font);
       draw_unicode_char(font, color::white, icon, ALLEGRO_ALIGN_CENTER, place.size.x/2, place.size.y/2 - line_height/2-1);
    }
@@ -57,7 +57,7 @@ public:
    MyMediaPlayer(FGUIWidget *parent)
       : FGUIWindow(parent, 650, 500, 200, 170)
       , filename("water_4.wav")
-      , sound(af::samples[filename])
+      , sound(Framework::samples[filename])
       , progress_bar(NULL)
       , play_button(NULL)
       , stop_button(NULL)
@@ -242,7 +242,7 @@ public:
          virtual_memory.set(parsed_key_val.first, parsed_key_val.second);
          virtual_memory.save(virtual_memory_filename);
       }
-      else if (message_caught = (message == "close_window")) af::shutdown_program = true;
+      else if (message_caught = (message == "close_window")) Framework::shutdown_program = true;
       else if (message_caught = Screen::signal_has_header("set_progress_bar", message))
       {
          std::string val = Screen::strip_signal_header("set_progress_bar", message);
@@ -253,17 +253,17 @@ public:
       }
       else if (message_caught = (message == "shrink"))
       {
-         af::motion.cmove_to(&place.scale.x, 0.86, 0.3);
-         af::motion.cmove_to(&place.scale.y, 0.86, 0.3);
+         Framework::motion.cmove_to(&place.scale.x, 0.86, 0.3);
+         Framework::motion.cmove_to(&place.scale.y, 0.86, 0.3);
       }
       else if (message_caught = (message == "grow"))
       {
-         af::motion.cmove_to(&place.scale.x, 1, 0.3);
-         af::motion.cmove_to(&place.scale.y, 1, 0.3);
+         Framework::motion.cmove_to(&place.scale.x, 1, 0.3);
+         Framework::motion.cmove_to(&place.scale.y, 1, 0.3);
       }
       else if (message_caught = (message == "exit"))
       {
-         af::shutdown_program = true;
+         Framework::shutdown_program = true;
       }
       else if (message_caught = Screen::signal_has_header("set_music", message))
       {
@@ -281,8 +281,8 @@ public:
    void on_mouse_down() override
    {
       FGUIWindow::on_mouse_down();
-      mouse_down_x = af::current_event->mouse.x;
-      mouse_down_y = af::current_event->mouse.y;
+      mouse_down_x = Framework::current_event->mouse.x;
+      mouse_down_y = Framework::current_event->mouse.y;
    }
    void on_drag(float x, float y, float mx, float my) override
    {
@@ -344,14 +344,14 @@ public:
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
-   //Display *display = af::create_display(800, 720);
+   Framework::initialize();
+   //Display *display = Framework::create_display(800, 720);
 
    Display *display = new Display(800, 720, ALLEGRO_NOFRAME);
-   al_register_event_source(af::event_queue, al_get_display_event_source(display->al_display));
+   al_register_event_source(Framework::event_queue, al_get_display_event_source(display->al_display));
 
    Project *main = new Project(display);
-   af::run_loop();
+   Framework::run_loop();
 
    return 0;
 }

--- a/examples/gui/ex_framed_window.cpp
+++ b/examples/gui/ex_framed_window.cpp
@@ -64,10 +64,10 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display();
+   Framework::initialize();
+   Display *display = Framework::create_display();
    Project *proj = new Project(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/gui/ex_function_parser.cpp
+++ b/examples/gui/ex_function_parser.cpp
@@ -392,12 +392,12 @@ public:
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
-   Display *display = af::create_display(WIDTH + PADDING*2, 600, false);
+   Framework::initialize();
+   Display *display = Framework::create_display(WIDTH + PADDING*2, 600, false);
 
    Project *proj = new Project(display);
 
-   af::run_loop();
+   Framework::run_loop();
 
    return 0;
 }

--- a/examples/gui/ex_keyboard_joystick_modes.cpp
+++ b/examples/gui/ex_keyboard_joystick_modes.cpp
@@ -47,7 +47,7 @@ public:
    FlareGUIJoystick(Display *display)
       : FGUIScreen(display)
       , notification_screen(NULL)
-      , font(Framework::fonts["DroidSerif.ttf 20"])
+      , font(Framework::font("DroidSerif.ttf 20"))
       //, last_focused_ancestor(0)
       //, joy_as_mouse(false)
       //, joy_vertical_pos(0)
@@ -57,7 +57,7 @@ public:
       , submit_button(NULL)
    {
       //FGUIScreen::draw_focused_outline = false;
-      notification_screen = new SimpleNotificationScreen(display, Framework::fonts["DroidSerif.ttf 16"]);
+      notification_screen = new SimpleNotificationScreen(display, Framework::font("DroidSerif.ttf 16"));
 
       float button_x = 800/2;
       float button_y = 200;

--- a/examples/gui/ex_keyboard_joystick_modes.cpp
+++ b/examples/gui/ex_keyboard_joystick_modes.cpp
@@ -47,7 +47,7 @@ public:
    FlareGUIJoystick(Display *display)
       : FGUIScreen(display)
       , notification_screen(NULL)
-      , font(af::fonts["DroidSerif.ttf 20"])
+      , font(Framework::fonts["DroidSerif.ttf 20"])
       //, last_focused_ancestor(0)
       //, joy_as_mouse(false)
       //, joy_vertical_pos(0)
@@ -57,7 +57,7 @@ public:
       , submit_button(NULL)
    {
       //FGUIScreen::draw_focused_outline = false;
-      notification_screen = new SimpleNotificationScreen(display, af::fonts["DroidSerif.ttf 16"]);
+      notification_screen = new SimpleNotificationScreen(display, Framework::fonts["DroidSerif.ttf 16"]);
 
       float button_x = 800/2;
       float button_y = 200;
@@ -124,12 +124,12 @@ public:
    //{
    //   FGUIScreen::joy_down_func();
 
-      //std::cout << "joy button " << af::current_event->joystick.button << std::endl;
+      //std::cout << "joy button " << Framework::current_event->joystick.button << std::endl;
 
-      //if (af::current_event->joystick.button ==  5) jump_focus_to_next_widget(); // XBOX Controller shoulder trigger button
-      //if (af::current_event->joystick.button ==  4) jump_focus_to_previous_widget(); // XBOX Controller shoulder trigger button
+      //if (Framework::current_event->joystick.button ==  5) jump_focus_to_next_widget(); // XBOX Controller shoulder trigger button
+      //if (Framework::current_event->joystick.button ==  4) jump_focus_to_previous_widget(); // XBOX Controller shoulder trigger button
 /*
-      if (af::current_event->joystick.button ==  0)
+      if (Framework::current_event->joystick.button ==  0)
       {
          // does only 1 button
          FOR (children.children)
@@ -154,11 +154,11 @@ public:
       ev.type = ALLEGRO_EVENT_KEY_DOWN;
       ev.any.timestamp = al_get_time();
       ev.any.type = ALLEGRO_EVENT_KEY_DOWN;
-      ev.any.source = &af::_user_event_src_for_faking_events;
+      ev.any.source = &Framework::_user_event_src_for_faking_events;
       ev.keyboard.type = ALLEGRO_EVENT_KEY_DOWN;
       ev.keyboard.keycode = ALLEGRO_KEY_ESCAPE;
       ev.keyboard.display = al_get_current_display();
-      al_emit_user_event(&af::_user_event_src_for_faking_events , &ev , NULL);
+      al_emit_user_event(&Framework::_user_event_src_for_faking_events , &ev , NULL);
       */
    //}
    //void joy_axis_func() override
@@ -166,8 +166,8 @@ public:
    //   FGUIScreen::joy_axis_func();
 
       //use_joystick_as_mouse = true;
-      //if (af::current_event->joystick.axis == 0) joy_horizontal_pos = af::current_event->joystick.pos;
-      //if (af::current_event->joystick.axis == 1) joy_vertical_pos = af::current_event->joystick.pos;
+      //if (Framework::current_event->joystick.axis == 0) joy_horizontal_pos = Framework::current_event->joystick.pos;
+      //if (Framework::current_event->joystick.axis == 1) joy_vertical_pos = Framework::current_event->joystick.pos;
 
 
       //if (hide_mouse_cursor_on_widget_jump) al_show_mouse_cursor(display->display);
@@ -191,13 +191,13 @@ public:
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
+   Framework::initialize();
 
-   //Display *display = af::create_display(1920, 1080, true);
-   Display *display = af::create_display(1000, 700);
+   //Display *display = Framework::create_display(1920, 1080, true);
+   Display *display = Framework::create_display(1000, 700);
    FlareGUIJoystick *joystick_ex = new FlareGUIJoystick(display);
 
-   af::run_loop();
+   Framework::run_loop();
 
    return 0;
 }

--- a/examples/gui/ex_music_calculator.cpp
+++ b/examples/gui/ex_music_calculator.cpp
@@ -86,7 +86,7 @@ public:
    FGUITextInput *text_input;
    FGUIText *notation_text;
    std::string result_text;
-   Project() : FGUIScreen(af::create_display())
+   Project() : FGUIScreen(Framework::create_display())
       , music_render(al_create_bitmap(200, 80))
       , text_input(NULL)
       , notation_text(NULL)
@@ -164,8 +164,8 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
+   Framework::initialize();
    Project *p = new Project();
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }

--- a/examples/gui/ex_scroll_area.cpp
+++ b/examples/gui/ex_scroll_area.cpp
@@ -58,7 +58,7 @@ public:
       , scroll_view(NULL)
       //, settings_window(NULL)
    {
-      new FGUIImage(this, display->width()/2, display->height()/2, af::bitmaps["maybe_cooler2.png"]);
+      new FGUIImage(this, display->width()/2, display->height()/2, Framework::bitmaps["maybe_cooler2.png"]);
 
       FGUIWidget *canvas = build_canvas_for_scrollable_area();
       scroll_view = new FGUIScrollArea(this, display->width()/3, display->height()/2, canvas->place.size.x, 600, canvas);
@@ -104,9 +104,9 @@ public:
 
       //{
          // some example in-canvas elements
-         FGUIImage *img = new FGUIImage(canvas, canvas->place.size.x/2, 120, af::bitmaps["pic1.jpg"]);
+         FGUIImage *img = new FGUIImage(canvas, canvas->place.size.x/2, 120, Framework::bitmaps["pic1.jpg"]);
             img->place.rotation = 0.2;
-         new FGUIImage(canvas, canvas->place.size.x/2, 330, af::bitmaps["pic2.png"]);
+         new FGUIImage(canvas, canvas->place.size.x/2, 330, Framework::bitmaps["pic2.png"]);
          new FGUITextBox(canvas, canvas->place.size.x/2, 510, 300, 120,   "The content in this scroll area is a parent widget.");
          FGUITextList *text_list = new FGUITextList(canvas, canvas->place.size.x/2, 700, 300);
             text_list->add_item("Shoes");
@@ -139,9 +139,9 @@ public:
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
-   Display *display = af::create_display(Display::RESOLUTION_WXGA);
+   Framework::initialize();
+   Display *display = Framework::create_display(Display::RESOLUTION_WXGA);
    ScrollAreaExpampleProgram *proj = new ScrollAreaExpampleProgram(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }//

--- a/examples/gui/ex_scroll_area.cpp
+++ b/examples/gui/ex_scroll_area.cpp
@@ -58,7 +58,7 @@ public:
       , scroll_view(NULL)
       //, settings_window(NULL)
    {
-      new FGUIImage(this, display->width()/2, display->height()/2, Framework::bitmaps["maybe_cooler2.png"]);
+      new FGUIImage(this, display->width()/2, display->height()/2, Framework::bitmap("maybe_cooler2.png"));
 
       FGUIWidget *canvas = build_canvas_for_scrollable_area();
       scroll_view = new FGUIScrollArea(this, display->width()/3, display->height()/2, canvas->place.size.x, 600, canvas);
@@ -104,9 +104,9 @@ public:
 
       //{
          // some example in-canvas elements
-         FGUIImage *img = new FGUIImage(canvas, canvas->place.size.x/2, 120, Framework::bitmaps["pic1.jpg"]);
+         FGUIImage *img = new FGUIImage(canvas, canvas->place.size.x/2, 120, Framework::bitmap("pic1.jpg"));
             img->place.rotation = 0.2;
-         new FGUIImage(canvas, canvas->place.size.x/2, 330, Framework::bitmaps["pic2.png"]);
+         new FGUIImage(canvas, canvas->place.size.x/2, 330, Framework::bitmap("pic2.png"));
          new FGUITextBox(canvas, canvas->place.size.x/2, 510, 300, 120,   "The content in this scroll area is a parent widget.");
          FGUITextList *text_list = new FGUITextList(canvas, canvas->place.size.x/2, 700, 300);
             text_list->add_item("Shoes");

--- a/examples/gui/ex_scrollbar.cpp
+++ b/examples/gui/ex_scrollbar.cpp
@@ -35,10 +35,10 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display();
+   Framework::initialize();
+   Display *display = Framework::create_display();
    Project *proj = new Project(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/gui/ex_skeleton.cpp
+++ b/examples/gui/ex_skeleton.cpp
@@ -178,7 +178,7 @@ public:
 
    void on_timer() override
    {
-      bone_animator.update(af::time_now);
+      bone_animator.update(Framework::time_now);
 
       if (rotating)
       {
@@ -222,12 +222,12 @@ public:
 
    void on_key_char() override
    {
-      if (af::current_event->keyboard.keycode == ALLEGRO_KEY_UP)
+      if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_UP)
       {
          focus_bone_index++;
          if (focus_bone_index > bone_test->get_tree_size()) focus_bone_index = bone_test->get_tree_size();
       }
-      if (af::current_event->keyboard.keycode == ALLEGRO_KEY_DOWN)
+      if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_DOWN)
       {
          focus_bone_index--;
          if (focus_bone_index < 0) focus_bone_index = 0;
@@ -236,24 +236,24 @@ public:
 
    void on_key_down() override
    {
-      //std::cout << af::current_event->keyboard.keycode << std::endl;
-      if (af::current_event->keyboard.keycode == ALLEGRO_KEY_RIGHT)
+      //std::cout << Framework::current_event->keyboard.keycode << std::endl;
+      if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_RIGHT)
       {
          rotating = 1;
       }
-      if (af::current_event->keyboard.keycode == ALLEGRO_KEY_LEFT)
+      if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_LEFT)
       {
          rotating = -1;
       }
-      if (af::current_event->keyboard.keycode == ALLEGRO_KEY_F12)
+      if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_F12)
       {
          std::string screenshot_filename = take_screenshot();
          simple_notification_screen->spawn_notification("screenshot saved\n\"" + screenshot_filename + "\"");
       }
-      if (af::current_event->keyboard.keycode >= ALLEGRO_KEY_1 && af::current_event->keyboard.keycode <= ALLEGRO_KEY_9)
+      if (Framework::current_event->keyboard.keycode >= ALLEGRO_KEY_1 && Framework::current_event->keyboard.keycode <= ALLEGRO_KEY_9)
       {
-         int state_bank_num = af::current_event->keyboard.keycode - ALLEGRO_KEY_1;
-         if (af::key_shift)
+         int state_bank_num = Framework::current_event->keyboard.keycode - ALLEGRO_KEY_1;
+         if (Framework::key_shift)
          {
             //SkeletonState
             skeleton_states[state_bank_num].set(bone_test);
@@ -272,7 +272,7 @@ public:
             //std::cout << "moving to bank " << frame_bank_num << std::endl;
          }
       }
-      if (af::current_event->keyboard.keycode == ALLEGRO_KEY_L)
+      if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_L)
       {
          std::string filename = pick_filename();
          if (!filename.empty())
@@ -287,8 +287,8 @@ public:
 
    void on_key_up() override
    {
-      if (af::current_event->keyboard.keycode == ALLEGRO_KEY_RIGHT) rotating = 0;
-      if (af::current_event->keyboard.keycode == ALLEGRO_KEY_LEFT) rotating = 0;
+      if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_RIGHT) rotating = 0;
+      if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_LEFT) rotating = 0;
    }
 
    void joy_config_func() override
@@ -303,10 +303,10 @@ public:
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
-   Display *display = af::create_display(1600, 800);
+   Framework::initialize();
+   Display *display = Framework::create_display(1600, 800);
    SkeletonExampleProgram *prog = new SkeletonExampleProgram(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/gui/ex_text_list.cpp
+++ b/examples/gui/ex_text_list.cpp
@@ -24,10 +24,10 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display(1100, 700);
+   Framework::initialize();
+   Display *display = Framework::create_display(1100, 700);
    Project *project = new Project(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/gui/ex_widget_inspector.cpp
+++ b/examples/gui/ex_widget_inspector.cpp
@@ -83,8 +83,8 @@ public:
    {
       FGUIFramedWindow::on_draw();
 
-      ALLEGRO_FONT *font = af::fonts["DroidSans.ttf 15"];
-      ALLEGRO_FONT *font2 = af::fonts["DroidSans.ttf 15"];
+      ALLEGRO_FONT *font = Framework::fonts["DroidSans.ttf 15"];
+      ALLEGRO_FONT *font2 = Framework::fonts["DroidSans.ttf 15"];
       float x_cursor = 160;
       incrementer<float> y_cursor(60, 24);
 
@@ -176,9 +176,9 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display(800, 500);
+   Framework::initialize();
+   Display *display = Framework::create_display(800, 500);
    Project *proj = new Project(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }

--- a/examples/gui/ex_widget_inspector.cpp
+++ b/examples/gui/ex_widget_inspector.cpp
@@ -83,8 +83,8 @@ public:
    {
       FGUIFramedWindow::on_draw();
 
-      ALLEGRO_FONT *font = Framework::fonts["DroidSans.ttf 15"];
-      ALLEGRO_FONT *font2 = Framework::fonts["DroidSans.ttf 15"];
+      ALLEGRO_FONT *font = Framework::font("DroidSans.ttf 15");
+      ALLEGRO_FONT *font2 = Framework::font("DroidSans.ttf 15");
       float x_cursor = 160;
       incrementer<float> y_cursor(60, 24);
 

--- a/examples/gui/ex_widgets.cpp
+++ b/examples/gui/ex_widgets.cpp
@@ -45,10 +45,10 @@ public:
 
 int main(int argc, char **argv)
 {
-   af::initialize();
-   Display *display = af::create_display();
+   Framework::initialize();
+   Display *display = Framework::create_display();
    Project *project = new Project(display);
-   af::run_loop();
+   Framework::run_loop();
    return 0;
 }
 

--- a/examples/test_clipboard.cpp
+++ b/examples/test_clipboard.cpp
@@ -6,8 +6,8 @@
 
 int main(int argc, char *argv[])
 {
-   af::initialize();
-   Display *display = af::create_display(800, 600);
+   Framework::initialize();
+   Display *display = Framework::create_display(800, 600);
 
    std::cout << "the current clipboard text is \"" << Clipboard::get() << "\"" << std::endl;
    std::cout << "setting clipboard text" << std::endl;

--- a/examples/test_generated_textures.cpp
+++ b/examples/test_generated_textures.cpp
@@ -62,10 +62,10 @@ public:
 
 int main(int argc, char **argv)
 {
-	af::initialize();
-	Display *display = af::create_display(960, 540);
+	Framework::initialize();
+	Display *display = Framework::create_display(960, 540);
 	MyProject *proj = new MyProject(display);
-	af::run_loop();
+	Framework::run_loop();
 
 	return 0;
 }

--- a/include/allegro_flare/bin.h
+++ b/include/allegro_flare/bin.h
@@ -78,26 +78,16 @@ static bool bin_record_comp(const typename Bin<T>::Record *b1, const typename Bi
 
 template<class T>
 Bin<T>::Bin(std::string dir)
-	: directory(NULL)
+   : directory(NULL)
+   , record()
 {
-	__check_al_system_is_installed();
-	set_path(dir);
-	//al_append_path_component(directory, "data");
-	//al_append_path_component(directory, "bitmaps");
+   set_path(dir);
+   if (!al_is_system_installed())
+      std::cout << "DEPRECIATION ERROR: Bins can no longer be created prior to al_init(). You have probably tried to create a bin in the global namespace." << std::endl;
 }
 
 
 
-
-template<class T>
-void Bin<T>::__check_al_system_is_installed()
-{
-	if (!al_is_system_installed())
-	{
-		std::cout << "[warning Bin<T>::__check_al_system_is_installed()] auto_calling al_init();" << std::endl;
-		al_init();
-	}
-}
 
 
 template<class T>

--- a/include/allegro_flare/display.h
+++ b/include/allegro_flare/display.h
@@ -23,7 +23,7 @@ public:
 	};
 
 private:
-	friend class af;
+	friend class Framework;
 	friend class Screen; // <- eh for now, because of the display <-> screen relationship
 	static std::vector<Display *> displays; // used to be "instance"
 	static Display *find_display(ALLEGRO_DISPLAY *display);

--- a/include/allegro_flare/framework.h
+++ b/include/allegro_flare/framework.h
@@ -22,7 +22,7 @@ class Motion;
 
 
 
-class af
+class Framework
 {
 public:
 

--- a/include/allegro_flare/framework.h
+++ b/include/allegro_flare/framework.h
@@ -13,19 +13,30 @@
 #include <allegro_flare/display.h>
 #include <allegro_flare/screen.h>
 
-class FontBin;
-class SampleBin;
-class BitmapBin;
-class ModelBin;
-class Motion;
+#include <allegro_flare/bins/font_bin.h>
+#include <allegro_flare/bins/sample_bin.h>
+#include <allegro_flare/bins/bitmap_bin.h>
+#include <allegro_flare/bins/model_bin.h>
+#include <allegro_flare/motion.h>
 
 
 
 
 class Framework
 {
-public:
+private:
+   static Framework *instance;
+   static Framework *get_instance();
+   Framework(int val);
+   ~Framework();
 
+	FontBin fonts;
+	SampleBin samples;
+	BitmapBin bitmaps;
+	ModelBin models;
+	Motion motions;
+
+public:
 	static ALLEGRO_TEXTLOG *textlog;
 	static ALLEGRO_JOYSTICK *joystick; // this needs some updating to allow for multiple joysticks
 	static ALLEGRO_EVENT_QUEUE *event_queue;
@@ -40,11 +51,11 @@ public:
 	static int key_alt, key_shift, key_ctrl;
 	static bool drawing_profiler_graph;
 
-	static FontBin fonts;
-	static SampleBin samples;
-	static BitmapBin bitmaps;
-	static ModelBin models;
-	static Motion motion;
+   static ALLEGRO_FONT *font(std::string identifier);
+   static ALLEGRO_BITMAP *bitmap(std::string identifier);
+   static ALLEGRO_SAMPLE *sample(std::string identifier);
+   static ModelNew *model(std::string identifier);
+   static Motion &motion(); // we'll do this for now
 
 	static bool initialize(std::string config_filename="");
 	static Display *create_display(int width=1280, int height=720);

--- a/include/allegro_flare/screen.h
+++ b/include/allegro_flare/screen.h
@@ -15,7 +15,7 @@
 class Screen
 {
 private:
-	friend class af;
+	friend class Framework;
 	friend class Display;
 
 	static std::vector<Screen *> screens; // this was recently changed from "instance" to "screens"

--- a/source/display.cpp
+++ b/source/display.cpp
@@ -37,7 +37,7 @@ Display::Display(int width, int height, int display_flags)
 
 void Display::display_close_func()
 {
-	af::shutdown_program = true;
+	Framework::shutdown_program = true;
 }
 
 

--- a/source/framework.cpp
+++ b/source/framework.cpp
@@ -14,7 +14,7 @@
 
 
 
-bool af::initialize(std::string config_filename)
+bool Framework::initialize(std::string config_filename)
 {
 	if (initialized) return initialized;
 
@@ -64,16 +64,16 @@ bool af::initialize(std::string config_filename)
 }
 
 
-// TODO: get rid of all these silly af::create_display() overloads
+// TODO: get rid of all these silly Framework::create_display() overloads
 
 
-Display *af::create_display(int width, int height)
+Display *Framework::create_display(int width, int height)
 {
 	return create_display(width, height, false, -1);
 }
 
 
-Display *af::create_display(int width, int height, int display_flags)
+Display *Framework::create_display(int width, int height, int display_flags)
 {
 	Display *display = new Display(width, height, display_flags);
 	al_register_event_source(event_queue, al_get_display_event_source(display->al_display));
@@ -81,7 +81,7 @@ Display *af::create_display(int width, int height, int display_flags)
 }
 
 
-Display *af::create_display(int width, int height, int display_flags, int adapter)
+Display *Framework::create_display(int width, int height, int display_flags, int adapter)
 {
 	if (adapter!=-1) al_set_new_display_adapter(adapter);
 	Display *display = new Display(width, height, display_flags);
@@ -90,7 +90,7 @@ Display *af::create_display(int width, int height, int display_flags, int adapte
 }
 
 
-Display *af::create_display(int width, int height, bool fullscreen)
+Display *Framework::create_display(int width, int height, bool fullscreen)
 {
 	Display *display = new Display(width, height, fullscreen ? ALLEGRO_FULLSCREEN : ALLEGRO_WINDOWED);
 	al_register_event_source(event_queue, al_get_display_event_source(display->al_display));
@@ -98,7 +98,7 @@ Display *af::create_display(int width, int height, bool fullscreen)
 }
 
 
-Display *af::create_display(int width, int height, bool fullscreen, int adapter)
+Display *Framework::create_display(int width, int height, bool fullscreen, int adapter)
 {
 	if (adapter!=-1) al_set_new_display_adapter(adapter);
 	Display *display = new Display(width, height, fullscreen ? ALLEGRO_FULLSCREEN : ALLEGRO_WINDOWED);
@@ -109,7 +109,7 @@ Display *af::create_display(int width, int height, bool fullscreen, int adapter)
 
 
 
-Display *af::create_display(Display::resolution_t resolution)
+Display *Framework::create_display(Display::resolution_t resolution)
 {
 	int w, h;
 	int screen_flags = ALLEGRO_FLAGS_EMPTY;
@@ -157,14 +157,14 @@ Display *af::create_display(Display::resolution_t resolution)
 
 
 
-void af::use_screen(Screen *screen)
+void Framework::use_screen(Screen *screen)
 {
 	//current_screen = screen;
 }
 
 
 
-void af::run_loop()
+void Framework::run_loop()
 {
 	al_start_timer(primary_timer);
 
@@ -176,7 +176,7 @@ void af::run_loop()
 		
 		current_event = &this_event;
 		time_now = this_event.any.timestamp;
-		af::motion.update(time_now);
+		Framework::motion.update(time_now);
 
 		Screen::on_events(current_event);
 
@@ -193,23 +193,23 @@ void af::run_loop()
 					al_drop_next_event(event_queue);
 			break;
 		case ALLEGRO_EVENT_KEY_DOWN:
-			if (af::current_event->keyboard.keycode == ALLEGRO_KEY_LSHIFT
-				|| af::current_event->keyboard.keycode == ALLEGRO_KEY_RSHIFT) af::key_shift++;
-			if (af::current_event->keyboard.keycode == ALLEGRO_KEY_ALT
-				|| af::current_event->keyboard.keycode == ALLEGRO_KEY_ALTGR) af::key_alt++;
-			if (af::current_event->keyboard.keycode == ALLEGRO_KEY_RCTRL
-				|| af::current_event->keyboard.keycode == ALLEGRO_KEY_LCTRL) af::key_ctrl++;
+			if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_LSHIFT
+				|| Framework::current_event->keyboard.keycode == ALLEGRO_KEY_RSHIFT) Framework::key_shift++;
+			if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_ALT
+				|| Framework::current_event->keyboard.keycode == ALLEGRO_KEY_ALTGR) Framework::key_alt++;
+			if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_RCTRL
+				|| Framework::current_event->keyboard.keycode == ALLEGRO_KEY_LCTRL) Framework::key_ctrl++;
 			if (current_event->keyboard.keycode == ALLEGRO_KEY_F1)
 				drawing_profiler_graph = !drawing_profiler_graph; // toggle the profiler graph with F1
 			Screen::key_down_funcs();
 			break;
 		case ALLEGRO_EVENT_KEY_UP:
-			if (af::current_event->keyboard.keycode == ALLEGRO_KEY_LSHIFT
-				|| af::current_event->keyboard.keycode == ALLEGRO_KEY_RSHIFT) af::key_shift--;
-			if (af::current_event->keyboard.keycode == ALLEGRO_KEY_ALT
-				|| af::current_event->keyboard.keycode == ALLEGRO_KEY_ALTGR) af::key_alt--;
-			if (af::current_event->keyboard.keycode == ALLEGRO_KEY_RCTRL
-				|| af::current_event->keyboard.keycode == ALLEGRO_KEY_LCTRL) af::key_ctrl--;
+			if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_LSHIFT
+				|| Framework::current_event->keyboard.keycode == ALLEGRO_KEY_RSHIFT) Framework::key_shift--;
+			if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_ALT
+				|| Framework::current_event->keyboard.keycode == ALLEGRO_KEY_ALTGR) Framework::key_alt--;
+			if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_RCTRL
+				|| Framework::current_event->keyboard.keycode == ALLEGRO_KEY_LCTRL) Framework::key_ctrl--;
 			Screen::key_up_funcs();
 			break;
 		case ALLEGRO_EVENT_KEY_CHAR:
@@ -279,7 +279,7 @@ void af::run_loop()
 
 
 
-void af::open_log_window()
+void Framework::open_log_window()
 {
 	if (textlog) return;
 
@@ -289,7 +289,7 @@ void af::open_log_window()
 
 
 
-void af::close_log_window()
+void Framework::close_log_window()
 {
 	if (!textlog) return;
 
@@ -299,7 +299,7 @@ void af::close_log_window()
 
 
 
-void af::log(std::string message)
+void Framework::log(std::string message)
 {
 	if (!textlog) return;
 	al_append_native_text_log(textlog, message.c_str());
@@ -307,27 +307,27 @@ void af::log(std::string message)
 
 
 
-ALLEGRO_TEXTLOG *af::textlog = NULL;
-ALLEGRO_JOYSTICK *af::joystick = NULL;
-ALLEGRO_EVENT_QUEUE *af::event_queue = NULL;
-ALLEGRO_TIMER *af::primary_timer = NULL;
-ALLEGRO_FONT *af::builtin_font = NULL;
-bool af::shutdown_program = false;
-Screen *af::current_screen = NULL;
-double af::time_now = 0;
-ALLEGRO_EVENT *af::current_event = NULL;
-bool af::initialized = false;
-int af::key_alt = 0;
-int af::key_shift = 0;
-int af::key_ctrl = 0;
-bool af::drawing_profiler_graph = false;
+ALLEGRO_TEXTLOG *Framework::textlog = NULL;
+ALLEGRO_JOYSTICK *Framework::joystick = NULL;
+ALLEGRO_EVENT_QUEUE *Framework::event_queue = NULL;
+ALLEGRO_TIMER *Framework::primary_timer = NULL;
+ALLEGRO_FONT *Framework::builtin_font = NULL;
+bool Framework::shutdown_program = false;
+Screen *Framework::current_screen = NULL;
+double Framework::time_now = 0;
+ALLEGRO_EVENT *Framework::current_event = NULL;
+bool Framework::initialized = false;
+int Framework::key_alt = 0;
+int Framework::key_shift = 0;
+int Framework::key_ctrl = 0;
+bool Framework::drawing_profiler_graph = false;
 
 // note: for the bins to be constructed here, al_init() needs to be called
-// prior to its intended place of af::initialize();  Maybe address this in
+// prior to its intended place of Framework::initialize();  Maybe address this in
 // the future.
-BitmapBin af::bitmaps("data/bitmaps");
-FontBin af::fonts("data/fonts");
-SampleBin af::samples("data/samples");
-ModelBin af::models("data/models");
-Motion af::motion(200);
+BitmapBin Framework::bitmaps("data/bitmaps");
+FontBin Framework::fonts("data/fonts");
+SampleBin Framework::samples("data/samples");
+ModelBin Framework::models("data/models");
+Motion Framework::motion(200);
 

--- a/source/framework.cpp
+++ b/source/framework.cpp
@@ -14,6 +14,59 @@
 
 
 
+Framework *Framework::get_instance()
+{
+   if (!instance) instance = new Framework(1);
+   return instance;
+}
+
+
+
+Framework::Framework(int val)
+   : fonts("data/fonts")
+   , samples("data/samples")
+   , bitmaps("data/bitmaps")
+   , models("data/models")
+   , motions(200)
+{}
+
+
+
+ALLEGRO_FONT *Framework::font(std::string identifier)
+{
+   return get_instance()->fonts[identifier];
+}
+
+
+
+ALLEGRO_BITMAP *Framework::bitmap(std::string identifier)
+{
+   return get_instance()->bitmaps[identifier];
+}
+
+
+
+ALLEGRO_SAMPLE *Framework::sample(std::string identifier)
+{
+   return get_instance()->samples[identifier];
+}
+
+
+
+ModelNew *Framework::model(std::string identifier)
+{
+   return get_instance()->models[identifier];
+}
+
+
+
+Motion &Framework::motion()
+{
+   return get_instance()->motions;
+}
+
+
+
 bool Framework::initialize(std::string config_filename)
 {
 	if (initialized) return initialized;
@@ -176,7 +229,7 @@ void Framework::run_loop()
 		
 		current_event = &this_event;
 		time_now = this_event.any.timestamp;
-		Framework::motion.update(time_now);
+		get_instance()->motions.update(time_now);
 
 		Screen::on_events(current_event);
 
@@ -322,12 +375,5 @@ int Framework::key_shift = 0;
 int Framework::key_ctrl = 0;
 bool Framework::drawing_profiler_graph = false;
 
-// note: for the bins to be constructed here, al_init() needs to be called
-// prior to its intended place of Framework::initialize();  Maybe address this in
-// the future.
-BitmapBin Framework::bitmaps("data/bitmaps");
-FontBin Framework::fonts("data/fonts");
-SampleBin Framework::samples("data/samples");
-ModelBin Framework::models("data/models");
-Motion Framework::motion(200);
+Framework *Framework::instance = NULL;
 

--- a/source/gui/button.cpp
+++ b/source/gui/button.cpp
@@ -15,7 +15,7 @@
 #include <allegro_flare/gui/surface_areas/box.h>
 #include <allegro_flare/gui/style_assets.h>
 
-#include <allegro_flare/allegro_flare.h> // for af::time_now
+#include <allegro_flare/allegro_flare.h> // for Framework::time_now
 
 
 
@@ -141,8 +141,8 @@ void FGUIButton::on_key_down()
    // NOTE! this is similar to the on_joy_down button too.
    if (!is_focused()) return;
 
-   if (af::current_event->keyboard.keycode == ALLEGRO_KEY_ENTER
-      || af::current_event->keyboard.keycode == ALLEGRO_KEY_SPACE
+   if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_ENTER
+      || Framework::current_event->keyboard.keycode == ALLEGRO_KEY_SPACE
       )
    {
       on_click();
@@ -156,7 +156,7 @@ void FGUIButton::on_joy_down()
    // NOTE! this is similar to the on_key_down button too.
    if (!mouse_over) return;
 
-   if (af::current_event->joystick.button == 0)
+   if (Framework::current_event->joystick.button == 0)
    {
       on_click();
    }

--- a/source/gui/checkbox.cpp
+++ b/source/gui/checkbox.cpp
@@ -54,18 +54,18 @@ void FGUICheckbox::toggle()
    if (checked)
    {
       // check reveals
-      af::motion.cmove_to(&check_opacity, 1.0, speed * 0.5, interpolator::doubleFastIn);
-      af::motion.cmove_to(&check_placement.scale.x, 1.0, speed*0.85, interpolator::fastOut);
-      af::motion.cmove_to(&check_placement.scale.y, 1.0, speed*0.85, interpolator::fastOut);
-      af::motion.cmove_to(&check_placement.rotation, -0.1, speed, interpolator::fastOut);
+      Framework::motion.cmove_to(&check_opacity, 1.0, speed * 0.5, interpolator::doubleFastIn);
+      Framework::motion.cmove_to(&check_placement.scale.x, 1.0, speed*0.85, interpolator::fastOut);
+      Framework::motion.cmove_to(&check_placement.scale.y, 1.0, speed*0.85, interpolator::fastOut);
+      Framework::motion.cmove_to(&check_placement.rotation, -0.1, speed, interpolator::fastOut);
    }
    else
    {
       // check removes
-      af::motion.cmove_to(&check_opacity, 0.0, speed, interpolator::doubleFastOut);
-      af::motion.cmove_to(&check_placement.scale.x, 0.0, speed, interpolator::slowIn);
-      af::motion.cmove_to(&check_placement.scale.y, 0.0, speed, interpolator::slowIn);
-      af::motion.cmove_to(&check_placement.rotation, -0.4, speed, interpolator::linear);
+      Framework::motion.cmove_to(&check_opacity, 0.0, speed, interpolator::doubleFastOut);
+      Framework::motion.cmove_to(&check_placement.scale.x, 0.0, speed, interpolator::slowIn);
+      Framework::motion.cmove_to(&check_placement.scale.y, 0.0, speed, interpolator::slowIn);
+      Framework::motion.cmove_to(&check_placement.rotation, -0.4, speed, interpolator::linear);
    }
 
    on_change();
@@ -106,8 +106,8 @@ void FGUICheckbox::on_click()
 void FGUICheckbox::on_key_char()
 {
    if (!focused) return;
-   if (af::current_event->keyboard.keycode == ALLEGRO_KEY_SPACE
-      || af::current_event->keyboard.keycode == ALLEGRO_KEY_ENTER)
+   if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_SPACE
+      || Framework::current_event->keyboard.keycode == ALLEGRO_KEY_ENTER)
    {
       toggle();
    }
@@ -121,7 +121,7 @@ void FGUICheckbox::on_joy_down()
 
    // TODO: this should not be hard-coded as button 0, it should be coded
    // as the "ENTER" button or "ACTIVATE" or whatever in the joystick config
-   if (af::current_event->joystick.button == 0)
+   if (Framework::current_event->joystick.button == 0)
       toggle();
 }
 
@@ -143,7 +143,7 @@ void FGUICheckbox::on_draw()
 
 
    // draw the check
-   ALLEGRO_FONT *font_awesome = af::fonts["FontAwesome.otf " + tostring(((int)(place.size.x*1.75)))];
+   ALLEGRO_FONT *font_awesome = Framework::fonts["FontAwesome.otf " + tostring(((int)(place.size.x*1.75)))];
 
    static ALLEGRO_USTR *ustr = al_ustr_new("");
    al_ustr_set_chr(ustr, 0, font_awesome::ok);

--- a/source/gui/checkbox.cpp
+++ b/source/gui/checkbox.cpp
@@ -54,18 +54,18 @@ void FGUICheckbox::toggle()
    if (checked)
    {
       // check reveals
-      Framework::motion.cmove_to(&check_opacity, 1.0, speed * 0.5, interpolator::doubleFastIn);
-      Framework::motion.cmove_to(&check_placement.scale.x, 1.0, speed*0.85, interpolator::fastOut);
-      Framework::motion.cmove_to(&check_placement.scale.y, 1.0, speed*0.85, interpolator::fastOut);
-      Framework::motion.cmove_to(&check_placement.rotation, -0.1, speed, interpolator::fastOut);
+      Framework::motion().cmove_to(&check_opacity, 1.0, speed * 0.5, interpolator::doubleFastIn);
+      Framework::motion().cmove_to(&check_placement.scale.x, 1.0, speed*0.85, interpolator::fastOut);
+      Framework::motion().cmove_to(&check_placement.scale.y, 1.0, speed*0.85, interpolator::fastOut);
+      Framework::motion().cmove_to(&check_placement.rotation, -0.1, speed, interpolator::fastOut);
    }
    else
    {
       // check removes
-      Framework::motion.cmove_to(&check_opacity, 0.0, speed, interpolator::doubleFastOut);
-      Framework::motion.cmove_to(&check_placement.scale.x, 0.0, speed, interpolator::slowIn);
-      Framework::motion.cmove_to(&check_placement.scale.y, 0.0, speed, interpolator::slowIn);
-      Framework::motion.cmove_to(&check_placement.rotation, -0.4, speed, interpolator::linear);
+      Framework::motion().cmove_to(&check_opacity, 0.0, speed, interpolator::doubleFastOut);
+      Framework::motion().cmove_to(&check_placement.scale.x, 0.0, speed, interpolator::slowIn);
+      Framework::motion().cmove_to(&check_placement.scale.y, 0.0, speed, interpolator::slowIn);
+      Framework::motion().cmove_to(&check_placement.rotation, -0.4, speed, interpolator::linear);
    }
 
    on_change();
@@ -143,7 +143,7 @@ void FGUICheckbox::on_draw()
 
 
    // draw the check
-   ALLEGRO_FONT *font_awesome = Framework::fonts["FontAwesome.otf " + tostring(((int)(place.size.x*1.75)))];
+   ALLEGRO_FONT *font_awesome = Framework::font("FontAwesome.otf " + tostring(((int)(place.size.x*1.75))));
 
    static ALLEGRO_USTR *ustr = al_ustr_new("");
    al_ustr_set_chr(ustr, 0, font_awesome::ok);

--- a/source/gui/dial.cpp
+++ b/source/gui/dial.cpp
@@ -41,14 +41,14 @@ float FGUIDial::get_value()
 
 void FGUIDial::on_mouse_down()
 {
-   al_hide_mouse_cursor(af::current_event->mouse.display);
+   al_hide_mouse_cursor(Framework::current_event->mouse.display);
 }
 
 
 
 void FGUIDial::on_mouse_up()
 {
-   al_show_mouse_cursor(af::current_event->mouse.display);
+   al_show_mouse_cursor(Framework::current_event->mouse.display);
 }
 
 
@@ -60,7 +60,7 @@ void FGUIDial::on_drag(float x, float y, float dx, float dy)
    set_value(adjusted_val);
 
    // prevent the mouse cursor from moving on the screen
-   al_set_mouse_xy(af::current_event->mouse.display, x-dx, y-dy);
+   al_set_mouse_xy(Framework::current_event->mouse.display, x-dx, y-dy);
 }
 
 

--- a/source/gui/framed_window.cpp
+++ b/source/gui/framed_window.cpp
@@ -73,8 +73,8 @@ void FGUIFramedWindow::on_draw()
    draw_window_frame_around(0, 0, place.size.x, place.size.y);
 
    // draw the title text
-   al_draw_text(af::fonts["DroidSans.ttf 16"], color::black, 6+1, -25+2, 0, window_title.c_str());
-   al_draw_text(af::fonts["DroidSans.ttf 16"], color::white, 6, -25, 0, window_title.c_str());
+   al_draw_text(Framework::fonts["DroidSans.ttf 16"], color::black, 6+1, -25+2, 0, window_title.c_str());
+   al_draw_text(Framework::fonts["DroidSans.ttf 16"], color::white, 6, -25, 0, window_title.c_str());
 }
 
 

--- a/source/gui/framed_window.cpp
+++ b/source/gui/framed_window.cpp
@@ -73,8 +73,8 @@ void FGUIFramedWindow::on_draw()
    draw_window_frame_around(0, 0, place.size.x, place.size.y);
 
    // draw the title text
-   al_draw_text(Framework::fonts["DroidSans.ttf 16"], color::black, 6+1, -25+2, 0, window_title.c_str());
-   al_draw_text(Framework::fonts["DroidSans.ttf 16"], color::white, 6, -25, 0, window_title.c_str());
+   al_draw_text(Framework::font("DroidSans.ttf 16"), color::black, 6+1, -25+2, 0, window_title.c_str());
+   al_draw_text(Framework::font("DroidSans.ttf 16"), color::white, 6, -25, 0, window_title.c_str());
 }
 
 

--- a/source/gui/gui_screen.cpp
+++ b/source/gui/gui_screen.cpp
@@ -31,7 +31,7 @@ void FGUIScreen::primary_timer_func()
 {
    if (use_joystick_as_mouse)
    {
-      if (af::joystick)
+      if (Framework::joystick)
       {
          float sensitivity = 8.0;
 
@@ -39,7 +39,7 @@ void FGUIScreen::primary_timer_func()
          al_get_mouse_state(&mouse_state);
 
          ALLEGRO_JOYSTICK_STATE joystick_state;
-         al_get_joystick_state(af::joystick, &joystick_state);
+         al_get_joystick_state(Framework::joystick, &joystick_state);
 
          // TODO:
          // right now the joystick axis to use for the mouse emulation is static,
@@ -66,12 +66,12 @@ void FGUIScreen::primary_timer_func()
 
 void FGUIScreen::mouse_axes_func()
 {
-   if (af::current_event->mouse.display != display->al_display) return;
+   if (Framework::current_event->mouse.display != display->al_display) return;
 
-   float mx = af::current_event->mouse.x;
-   float my = af::current_event->mouse.y;
-   float mdx = af::current_event->mouse.dx;
-   float mdy = af::current_event->mouse.dy;
+   float mx = Framework::current_event->mouse.x;
+   float my = Framework::current_event->mouse.y;
+   float mdx = Framework::current_event->mouse.dx;
+   float mdy = Framework::current_event->mouse.dy;
 
    FGUIWidget::mouse_axes_func(mx, my, mdx, mdy);
 }
@@ -80,7 +80,7 @@ void FGUIScreen::mouse_axes_func()
 
 void FGUIScreen::mouse_down_func()
 {
-   if (af::current_event->mouse.display != display->al_display) return;
+   if (Framework::current_event->mouse.display != display->al_display) return;
    FGUIWidget::mouse_down_func();
 }
 
@@ -88,7 +88,7 @@ void FGUIScreen::mouse_down_func()
 
 void FGUIScreen::mouse_up_func()
 {
-   if (af::current_event->mouse.display != display->al_display) return;
+   if (Framework::current_event->mouse.display != display->al_display) return;
    FGUIWidget::mouse_up_func();
 }
 
@@ -96,18 +96,18 @@ void FGUIScreen::mouse_up_func()
 
 void FGUIScreen::key_down_func()
 {
-   if (af::current_event->keyboard.display != display->al_display) return;
+   if (Framework::current_event->keyboard.display != display->al_display) return;
 
 
    // these next two conditionals are for keyboard/joystick navigation of widgets
 
 /*
-   if (af::current_event->keyboard.keycode == ALLEGRO_KEY_TAB)
+   if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_TAB)
    {
-      if (af::key_shift) jump_focus_to_ancestor_by_delta(true);// jump_focus_to_previous_direct_descendent();
+      if (Framework::key_shift) jump_focus_to_ancestor_by_delta(true);// jump_focus_to_previous_direct_descendent();
       else jump_focus_to_ancestor_by_delta(); //jump_focus_to_next_direct_descendent();
    }
-   if (af::current_event->keyboard.keycode == ALLEGRO_KEY_ESCAPE)
+   if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_ESCAPE)
    {
       children.unfocus_all();
       al_show_mouse_cursor(display->display); // restore visibility of the cursor here
@@ -121,7 +121,7 @@ void FGUIScreen::key_down_func()
 
 void FGUIScreen::key_up_func()
 {
-   if (af::current_event->keyboard.display != display->al_display) return;
+   if (Framework::current_event->keyboard.display != display->al_display) return;
    FGUIWidget::key_up_func();
 }
 
@@ -129,7 +129,7 @@ void FGUIScreen::key_up_func()
 
 void FGUIScreen::key_char_func()
 {
-   if (af::current_event->keyboard.display != display->al_display) return;
+   if (Framework::current_event->keyboard.display != display->al_display) return;
 
    FGUIWidget::key_char_func();
 }
@@ -140,8 +140,8 @@ void FGUIScreen::joy_down_func()
 {
 /*
    // for joystick / keyboard navigation of widgets
-   if (af::current_event->joystick.button ==  5) jump_focus_to_ancestor_by_delta(); // XBOX Controller right shoulder trigger button
-   if (af::current_event->joystick.button ==  4) jump_focus_to_ancestor_by_delta(true); // XBOX Controller left shoulder trigger button
+   if (Framework::current_event->joystick.button ==  5) jump_focus_to_ancestor_by_delta(); // XBOX Controller right shoulder trigger button
+   if (Framework::current_event->joystick.button ==  4) jump_focus_to_ancestor_by_delta(true); // XBOX Controller left shoulder trigger button
 */
 
    FGUIWidget::joy_down_func();
@@ -151,7 +151,7 @@ void FGUIScreen::joy_down_func()
 
 void FGUIScreen::joy_up_func()
 {
-//   if (af::current_event->keyboard.display != display->display) return;
+//   if (Framework::current_event->keyboard.display != display->display) return;
    FGUIWidget::joy_up_func();
 }
 
@@ -161,8 +161,8 @@ void FGUIScreen::joy_axis_func()
 {
 // this stuff is now polled on the timer
 //   use_joystick_as_mouse = true;
-//   if (af::current_event->joystick.axis == 0) joy_horizontal_pos = af::current_event->joystick.pos;
-//   if (af::current_event->joystick.axis == 1) joy_vertical_pos = af::current_event->joystick.pos;
+//   if (Framework::current_event->joystick.axis == 0) joy_horizontal_pos = Framework::current_event->joystick.pos;
+//   if (Framework::current_event->joystick.axis == 1) joy_vertical_pos = Framework::current_event->joystick.pos;
 
    FGUIWidget::joy_axis_func();
 }

--- a/source/gui/progress_bar.cpp
+++ b/source/gui/progress_bar.cpp
@@ -33,7 +33,7 @@ FGUIProgressBar::FGUIProgressBar(FGUIWidget *parent, float x, float y, float w, 
 void FGUIProgressBar::set_val(float normalized_val)
 {
    normalized_val = limit<float>(0, 1, normalized_val);
-   af::motion.cmove_to(&val, normalized_val, update_speed, interpolator::doubleFastIn);
+   Framework::motion.cmove_to(&val, normalized_val, update_speed, interpolator::doubleFastIn);
 }
 
 

--- a/source/gui/progress_bar.cpp
+++ b/source/gui/progress_bar.cpp
@@ -33,7 +33,7 @@ FGUIProgressBar::FGUIProgressBar(FGUIWidget *parent, float x, float y, float w, 
 void FGUIProgressBar::set_val(float normalized_val)
 {
    normalized_val = limit<float>(0, 1, normalized_val);
-   Framework::motion.cmove_to(&val, normalized_val, update_speed, interpolator::doubleFastIn);
+   Framework::motion().cmove_to(&val, normalized_val, update_speed, interpolator::doubleFastIn);
 }
 
 

--- a/source/gui/scaled_text.cpp
+++ b/source/gui/scaled_text.cpp
@@ -26,7 +26,7 @@ std::string FGUIScaledText::_get_font_index_str()
 void FGUIScaledText::refresh_render()
 {
    // for easy life
-   ALLEGRO_FONT *scaled_font = Framework::fonts[_get_font_index_str()];
+   ALLEGRO_FONT *scaled_font = Framework::font(_get_font_index_str());
 
    // save the previous state
    ALLEGRO_STATE previous_state;

--- a/source/gui/scaled_text.cpp
+++ b/source/gui/scaled_text.cpp
@@ -26,7 +26,7 @@ std::string FGUIScaledText::_get_font_index_str()
 void FGUIScaledText::refresh_render()
 {
    // for easy life
-   ALLEGRO_FONT *scaled_font = af::fonts[_get_font_index_str()];
+   ALLEGRO_FONT *scaled_font = Framework::fonts[_get_font_index_str()];
 
    // save the previous state
    ALLEGRO_STATE previous_state;

--- a/source/gui/scroll_area.cpp
+++ b/source/gui/scroll_area.cpp
@@ -87,7 +87,7 @@ void FGUIScrollArea::on_timer()
 void FGUIScrollArea::on_mouse_wheel()
 {
    //if (focused && !v_slider->is_focused())
-   //   v_slider->set_val(v_slider->get_val() + af::current_event->mouse.dz * v_slider->wheel_sensitivity);
+   //   v_slider->set_val(v_slider->get_val() + Framework::current_event->mouse.dz * v_slider->wheel_sensitivity);
 }
 
 

--- a/source/gui/scrollbar.cpp
+++ b/source/gui/scrollbar.cpp
@@ -163,8 +163,8 @@ void FGUIScrollBar::set_position(float position_in_unit_value)
 }
 void FGUIScrollBar::on_key_down()
 {
-   if (af::current_event->keyboard.keycode == ALLEGRO_KEY_DOWN) step_down();
-   else if (af::current_event->keyboard.keycode == ALLEGRO_KEY_UP) step_up();
+   if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_DOWN) step_down();
+   else if (Framework::current_event->keyboard.keycode == ALLEGRO_KEY_UP) step_up();
 }
 void FGUIScrollBar::on_draw() {}
 void FGUIScrollBar::on_change()

--- a/source/gui/slider.cpp
+++ b/source/gui/slider.cpp
@@ -83,7 +83,7 @@ void FGUIVerticalSlider::on_mouse_move(float x, float y, float dx, float dy)
 
 void FGUIVerticalSlider::on_mouse_down()
 {
-   //if (mouse_over && af::current_event->mouse.button == 1) set_val_by_y(mouse_y);
+   //if (mouse_over && Framework::current_event->mouse.button == 1) set_val_by_y(mouse_y);
    if (mouse_over)
    {
       set_val_by_y(mouse_y);
@@ -105,7 +105,7 @@ void FGUIVerticalSlider::on_drag(float x, float y, float dx, float dy)
 
 void FGUIVerticalSlider::on_mouse_wheel()
 {
-   if (focused) set_val(get_val() + af::current_event->mouse.dz * wheel_sensitivity);
+   if (focused) set_val(get_val() + Framework::current_event->mouse.dz * wheel_sensitivity);
 }
 
 
@@ -115,7 +115,7 @@ void FGUIVerticalSlider::on_key_char()
    if (!focused) return;
    float increment_dist = 0.1;
    if (num_notches >= 3) increment_dist = 1.0 / num_notches;
-   switch (af::current_event->keyboard.keycode)
+   switch (Framework::current_event->keyboard.keycode)
    {
       case ALLEGRO_KEY_UP:
          set_val(val + increment_dist);

--- a/source/gui/spinner.cpp
+++ b/source/gui/spinner.cpp
@@ -9,7 +9,7 @@
 
 #include <allegro_flare/gui/surface_areas/box.h>
 
-#include <allegro_flare/framework.h> // for af::current_event 
+#include <allegro_flare/framework.h> // for Framework::current_event 
 
 
 
@@ -55,7 +55,7 @@ void FGUISpinner::on_key_char()
 {
    if (!focused) return;
 
-   switch(af::current_event->keyboard.keycode)
+   switch(Framework::current_event->keyboard.keycode)
    {
    case ALLEGRO_KEY_UP:
    case ALLEGRO_KEY_PAD_PLUS:

--- a/source/gui/text.cpp
+++ b/source/gui/text.cpp
@@ -16,7 +16,7 @@
 FGUIText::FGUIText(FGUIWidget *parent, float x, float y, std::string text)
    : FGUIWidget(parent, new FGUISurfaceAreaBox(x, y, 200, 20)) // just set arbitrary width and height
    , text(text)
-   , font(af::fonts["DroidSans.ttf 20"])
+   , font(Framework::fonts["DroidSans.ttf 20"])
    , font_color(color::white)
 {
    attr.set(FGUI_ATTR__FGUI_WIDGET_TYPE, "FGUIText");

--- a/source/gui/text.cpp
+++ b/source/gui/text.cpp
@@ -16,7 +16,7 @@
 FGUIText::FGUIText(FGUIWidget *parent, float x, float y, std::string text)
    : FGUIWidget(parent, new FGUISurfaceAreaBox(x, y, 200, 20)) // just set arbitrary width and height
    , text(text)
-   , font(Framework::fonts["DroidSans.ttf 20"])
+   , font(Framework::font("DroidSans.ttf 20"))
    , font_color(color::white)
 {
    attr.set(FGUI_ATTR__FGUI_WIDGET_TYPE, "FGUIText");

--- a/source/gui/text_area.cpp
+++ b/source/gui/text_area.cpp
@@ -87,7 +87,7 @@ FGUITextArea::FGUITextArea(FGUIWidget *parent, float x, float y, float w, float 
    : FGUIWidget(parent, new FGUISurfaceAreaBox(x, y, w, h))
    , cursor(0, 0)
    , full_text(text)
-   , font(af::fonts["DroidSans.ttf 20"])
+   , font(Framework::fonts["DroidSans.ttf 20"])
    , cursor_blink_counter(1)
 {
    attr.set(FGUI_ATTR__FGUI_WIDGET_TYPE, "FGUITextArea");
@@ -331,7 +331,7 @@ void FGUITextArea::on_draw()
 
 void FGUITextArea::on_key_down()
 {
-   int keycode = af::current_event->keyboard.keycode;
+   int keycode = Framework::current_event->keyboard.keycode;
    if (keycode == ALLEGRO_KEY_RSHIFT || keycode == ALLEGRO_KEY_LSHIFT)
    {
       // note: this should still activate even if the textarea widget is not focused
@@ -343,7 +343,7 @@ void FGUITextArea::on_key_down()
 
 void FGUITextArea::on_key_up()
 {
-   int keycode = af::current_event->keyboard.keycode;
+   int keycode = Framework::current_event->keyboard.keycode;
    if (keycode == ALLEGRO_KEY_RSHIFT || keycode == ALLEGRO_KEY_LSHIFT)
    {
       // note: this should still activate even if the textarea widget is not focused
@@ -364,16 +364,16 @@ void FGUITextArea::on_key_char()
 
    cursor_blink_counter = 1;
 
-   int unichar = af::current_event->keyboard.unichar;
-   int keycode = af::current_event->keyboard.keycode;
-   int modifier = af::current_event->keyboard.modifiers;
+   int unichar = Framework::current_event->keyboard.unichar;
+   int keycode = Framework::current_event->keyboard.keycode;
+   int modifier = Framework::current_event->keyboard.modifiers;
 
    // test cut-copy-paste
    if ((keycode == ALLEGRO_KEY_C
       || keycode == ALLEGRO_KEY_X
       || keycode == ALLEGRO_KEY_V
       || keycode == ALLEGRO_KEY_A)
-      && af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+      && Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
    {
       //std::cout << "cut-copy-pate" << std::endl;
       if (keycode == ALLEGRO_KEY_A)
@@ -415,7 +415,7 @@ void FGUITextArea::on_key_char()
    }
    else if (keycode == ALLEGRO_KEY_RIGHT)
    {
-      if (af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+      if (Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
       {
          move_cursor_to_next_of("null");
       }
@@ -426,7 +426,7 @@ void FGUITextArea::on_key_char()
    }
    else if (keycode == ALLEGRO_KEY_LEFT)
    {
-      if (af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+      if (Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
       {
          move_cursor_to_previous_not_of("null");
       }

--- a/source/gui/text_area.cpp
+++ b/source/gui/text_area.cpp
@@ -87,7 +87,7 @@ FGUITextArea::FGUITextArea(FGUIWidget *parent, float x, float y, float w, float 
    : FGUIWidget(parent, new FGUISurfaceAreaBox(x, y, w, h))
    , cursor(0, 0)
    , full_text(text)
-   , font(Framework::fonts["DroidSans.ttf 20"])
+   , font(Framework::font("DroidSans.ttf 20"))
    , cursor_blink_counter(1)
 {
    attr.set(FGUI_ATTR__FGUI_WIDGET_TYPE, "FGUITextArea");

--- a/source/gui/text_box.cpp
+++ b/source/gui/text_box.cpp
@@ -6,7 +6,7 @@
 #include <allegro_flare/gui/widgets/text_box.h>
 #include <allegro_flare/gui/surface_areas/box.h>
 
-#include <allegro_flare/allegro_flare.h> // for af::fonts
+#include <allegro_flare/allegro_flare.h> // for Framework::fonts
 
 
 
@@ -16,7 +16,7 @@
 
 FGUITextBox::FGUITextBox(FGUIWidget *parent, float x, float y, float w, float h, std::string text)
    : FGUIWidget(parent, new FGUISurfaceAreaBox(x, y, w, h))
-   , font(af::fonts["DroidSans.ttf 20"])
+   , font(Framework::fonts["DroidSans.ttf 20"])
    , text(text)
    , text_color(color::black)
 {

--- a/source/gui/text_box.cpp
+++ b/source/gui/text_box.cpp
@@ -16,7 +16,7 @@
 
 FGUITextBox::FGUITextBox(FGUIWidget *parent, float x, float y, float w, float h, std::string text)
    : FGUIWidget(parent, new FGUISurfaceAreaBox(x, y, w, h))
-   , font(Framework::fonts["DroidSans.ttf 20"])
+   , font(Framework::font("DroidSans.ttf 20"))
    , text(text)
    , text_color(color::black)
 {

--- a/source/gui/text_input.cpp
+++ b/source/gui/text_input.cpp
@@ -5,7 +5,7 @@
 #include <allegro_flare/gui/widgets/text_input.h>
 
 
-#include <allegro_flare/allegro_flare.h> // for af::current_event and af::fonts
+#include <allegro_flare/allegro_flare.h> // for Framework::current_event and Framework::fonts
 
 #include <allegro_flare/gui/widget.h>
 #include <allegro_flare/gui/surface_areas/box.h>
@@ -20,7 +20,7 @@ FGUITextInput::FGUITextInput(FGUIWidget *parent, float x, float y, float w, floa
    , text("")
    , cursor_pos(0)
    , cursor_end(0)
-   , font(af::fonts["DroidSans.ttf 20"])
+   , font(Framework::fonts["DroidSans.ttf 20"])
    , cursor_blink_counter(0)
    , text_x_offset(0)
    , font_color(color::white)
@@ -159,8 +159,8 @@ void FGUITextInput::on_key_char()
 
    cursor_blink_counter = 1.0;
 
-   int unichar = af::current_event->keyboard.unichar;
-   int keycode = af::current_event->keyboard.keycode;
+   int unichar = Framework::current_event->keyboard.unichar;
+   int keycode = Framework::current_event->keyboard.keycode;
    bool printable = false;
 
    if ((unichar >= ' ') && (unichar <= '~'))
@@ -177,7 +177,7 @@ void FGUITextInput::on_key_char()
       || keycode == ALLEGRO_KEY_X
       || keycode == ALLEGRO_KEY_V
       || keycode == ALLEGRO_KEY_A)
-      && af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+      && Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
    {
       //std::cout << "cut-copy-pate" << std::endl;
       if (keycode == ALLEGRO_KEY_A)
@@ -212,7 +212,7 @@ void FGUITextInput::on_key_char()
       }
       else
       {
-         if (af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+         if (Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
          {
             cursor_pos = text.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", cursor_pos);
             if (cursor_pos == std::string::npos)
@@ -233,7 +233,7 @@ void FGUITextInput::on_key_char()
       }
       else
       {
-         if (af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+         if (Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
          {
             cursor_pos = text.find_last_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'\"", cursor_pos-1);
             if (cursor_pos == std::string::npos)
@@ -274,8 +274,8 @@ void FGUITextInput::on_key_char()
    }
    else if (keycode == ALLEGRO_KEY_BACKSPACE)
    {
-      if ((af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
-         && (af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_SHIFT))
+      if ((Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+         && (Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_SHIFT))
       {
          // do nothing in this specific case.
          goto keyout;
@@ -288,7 +288,7 @@ void FGUITextInput::on_key_char()
       }
       else
       {
-         if (af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+         if (Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
          {
             cursor_pos = text.find_last_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'\"", cursor_pos-1);
             if (cursor_pos == std::string::npos)
@@ -310,7 +310,7 @@ void FGUITextInput::on_key_char()
       {
          if (cursor_pos != text.size())
          {
-            if (af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
+            if (Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL)
             {
                //cursor = text.find_first_of("", cursor); ?
                cursor_pos = text.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", cursor_pos);
@@ -339,7 +339,7 @@ void FGUITextInput::on_key_char()
 
    keyout:
 
-   if (!(af::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_SHIFT) || printable)
+   if (!(Framework::current_event->keyboard.modifiers & ALLEGRO_KEYMOD_SHIFT) || printable)
       cursor_end = cursor_pos;
 }
 

--- a/source/gui/text_input.cpp
+++ b/source/gui/text_input.cpp
@@ -20,7 +20,7 @@ FGUITextInput::FGUITextInput(FGUIWidget *parent, float x, float y, float w, floa
    , text("")
    , cursor_pos(0)
    , cursor_end(0)
-   , font(Framework::fonts["DroidSans.ttf 20"])
+   , font(Framework::font("DroidSans.ttf 20"))
    , cursor_blink_counter(0)
    , text_x_offset(0)
    , font_color(color::white)

--- a/source/gui/text_list.cpp
+++ b/source/gui/text_list.cpp
@@ -78,7 +78,7 @@ void FGUITextList::move_selected_item(int delta)
 void FGUITextList::on_key_char()
 {
    if (!is_focused()) return;
-   switch(af::current_event->keyboard.keycode)
+   switch(Framework::current_event->keyboard.keycode)
    {
    case ALLEGRO_KEY_DOWN:
       move_selected_item(1);
@@ -147,7 +147,7 @@ void FGUITextList::joy_down_func()
    FGUIWidget::joy_down_func();
    if (!mouse_over) return;
 
-   if (af::current_event->joystick.button == 0) // TODO: this should not be a hard-coded "0"
+   if (Framework::current_event->joystick.button == 0) // TODO: this should not be a hard-coded "0"
    {
       select_at_mouse_cursor();
    }
@@ -174,7 +174,7 @@ void FGUITextList::draw_item(vec2d position, int index)
    position.y += item_padding;
    bool item_is_selected = index == (this->currently_selected_item);
 
-   ALLEGRO_FONT *font = af::fonts["DroidSans.ttf 18"];
+   ALLEGRO_FONT *font = Framework::fonts["DroidSans.ttf 18"];
 
    if (item_is_selected)
    {

--- a/source/gui/text_list.cpp
+++ b/source/gui/text_list.cpp
@@ -174,7 +174,7 @@ void FGUITextList::draw_item(vec2d position, int index)
    position.y += item_padding;
    bool item_is_selected = index == (this->currently_selected_item);
 
-   ALLEGRO_FONT *font = Framework::fonts["DroidSans.ttf 18"];
+   ALLEGRO_FONT *font = Framework::font("DroidSans.ttf 18");
 
    if (item_is_selected)
    {

--- a/source/gui/widget.cpp
+++ b/source/gui/widget.cpp
@@ -63,7 +63,7 @@ FGUIWidget::~FGUIWidget()
       };
 
       std::vector<float*> pacement_elements (_elem, _elem + sizeof(_elem) / sizeof(float*) );
-      Framework::motion.clear_animations_on(pacement_elements);
+      Framework::motion().clear_animations_on(pacement_elements);
    }
 }
 

--- a/source/gui/widget.cpp
+++ b/source/gui/widget.cpp
@@ -63,7 +63,7 @@ FGUIWidget::~FGUIWidget()
       };
 
       std::vector<float*> pacement_elements (_elem, _elem + sizeof(_elem) / sizeof(float*) );
-      af::motion.clear_animations_on(pacement_elements);
+      Framework::motion.clear_animations_on(pacement_elements);
    }
 }
 
@@ -169,7 +169,7 @@ void FGUIWidget::draw_func()
    if (focused && gimmie_super_screen()->draw_focused_outline)
    {
       al_draw_rounded_rectangle(0, 0, surface_area->placement.size.x, surface_area->placement.size.y, 3, 3, color::color(color::black, 0.2), 5);
-      al_draw_rounded_rectangle(0, 0, surface_area->placement.size.x, surface_area->placement.size.y, 3, 3, color::mix(gimmie_super_screen()->focused_outline_color, color::purple, 0.6+0.4*sin(af::time_now*3)), 1.5);
+      al_draw_rounded_rectangle(0, 0, surface_area->placement.size.x, surface_area->placement.size.y, 3, 3, color::mix(gimmie_super_screen()->focused_outline_color, color::purple, 0.6+0.4*sin(Framework::time_now*3)), 1.5);
    }
    */
 
@@ -225,7 +225,7 @@ void FGUIWidget::mouse_axes_func(float x, float y, float dx, float dy)
       on_drag(x, y, dx, dy);
    }
 
-   if (af::current_event->mouse.dz != 0 || af::current_event->mouse.dw != 0) on_mouse_wheel();
+   if (Framework::current_event->mouse.dz != 0 || Framework::current_event->mouse.dw != 0) on_mouse_wheel();
 }
 
 
@@ -347,7 +347,7 @@ void FGUIWidget::joy_down_func()
       family.children[i]->joy_down_func();
 
 
-   if (mouse_over && af::current_event->joystick.button == 0)
+   if (mouse_over && Framework::current_event->joystick.button == 0)
    {
       set_as_focused();
    }

--- a/source/gui/window.cpp
+++ b/source/gui/window.cpp
@@ -5,7 +5,7 @@
 
 #include <allegro_flare/gui/widgets/window.h>
 
-#include <allegro_flare/allegro_flare.h> // for tostring and af:: bins
+#include <allegro_flare/allegro_flare.h> // for tostring and Framework:: bins
 
 #include <allegro_flare/gui/surface_areas/box.h>
 #include <allegro_flare/gui/style_assets.h>
@@ -30,7 +30,7 @@ FGUIWindow::FGUIWindow(FGUIWidget *parent, float x, float y, float w, float h)
 void FGUIWindow::on_draw()
 {
    FGUIStyleAssets::draw_outset(0, 0, place.size.x, place.size.y);
-   draw_textured_rectangle(1, 1, place.size.x-1, place.size.y-1, af::bitmaps["rough.jpg"], color::color(color::white, 0.1));
+   draw_textured_rectangle(1, 1, place.size.x-1, place.size.y-1, Framework::bitmaps["rough.jpg"], color::color(color::white, 0.1));
 }
 
 

--- a/source/gui/window.cpp
+++ b/source/gui/window.cpp
@@ -30,7 +30,7 @@ FGUIWindow::FGUIWindow(FGUIWidget *parent, float x, float y, float w, float h)
 void FGUIWindow::on_draw()
 {
    FGUIStyleAssets::draw_outset(0, 0, place.size.x, place.size.y);
-   draw_textured_rectangle(1, 1, place.size.x-1, place.size.y-1, Framework::bitmaps["rough.jpg"], color::color(color::white, 0.1));
+   draw_textured_rectangle(1, 1, place.size.x-1, place.size.y-1, Framework::bitmap("rough.jpg"), color::color(color::white, 0.1));
 }
 
 

--- a/source/screens/filesys_change_notification_screen.cpp
+++ b/source/screens/filesys_change_notification_screen.cpp
@@ -25,14 +25,14 @@ FileSysChangeNotificationScreen *FileSysChangeNotificationScreen::instance = NUL
 FileSysChangeNotificationScreen::FileSysChangeNotificationScreen()
 {
 	al_init_user_event_source(&filesys_change_event_source);
-	al_register_event_source(af::event_queue, &filesys_change_event_source);
+	al_register_event_source(Framework::event_queue, &filesys_change_event_source);
 	// spawn watcher thread
 }
 
 
 FileSysChangeNotificationScreen::~FileSysChangeNotificationScreen()
 {
-	al_unregister_event_source(af::event_queue, &filesys_change_event_source);
+	al_unregister_event_source(Framework::event_queue, &filesys_change_event_source);
 	// join watcher thread
 }
 

--- a/source/screens/gamer_input_screen.cpp
+++ b/source/screens/gamer_input_screen.cpp
@@ -15,7 +15,7 @@ GamerInputScreen::GamerInputScreen(Display *display)
 	: Screen(display)
 {
 	al_init_user_event_source(&input_event_source);
-	al_register_event_source(af::event_queue, &input_event_source);
+	al_register_event_source(Framework::event_queue, &input_event_source);
 	setup_default_joystick_mapping_for_XBOX_360_CONTROLLER();
 	setup_default_keyboard_mapping_for_ARROW_KEYS();
 }
@@ -26,7 +26,7 @@ GamerInputScreen::~GamerInputScreen()
 {
 	// uninit user event source?
 	//al_init_user_event_source(&my_event_source);
-	al_unregister_event_source(af::event_queue, &input_event_source);
+	al_unregister_event_source(Framework::event_queue, &input_event_source);
 }
 
 
@@ -147,15 +147,15 @@ void GamerInputScreen::setup_default_joystick_mapping_for_XBOX_360_CONTROLLER()
 
 void GamerInputScreen::key_down_func()
 {
-	if (af::current_event->keyboard.keycode == button_up_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_UP);
-	else if (af::current_event->keyboard.keycode == button_down_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_DOWN);
-	else if (af::current_event->keyboard.keycode == button_left_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_LEFT);
-	else if (af::current_event->keyboard.keycode == button_right_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_RIGHT);
-	else if (af::current_event->keyboard.keycode == button_start_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_START);
-	else if (af::current_event->keyboard.keycode == button_back_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_BACK);
-	else if (af::current_event->keyboard.keycode == button_a_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_A);
-	else if (af::current_event->keyboard.keycode == button_b_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_B);
-	else if (af::current_event->keyboard.keycode == button_c_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_C);
+	if (Framework::current_event->keyboard.keycode == button_up_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_UP);
+	else if (Framework::current_event->keyboard.keycode == button_down_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_DOWN);
+	else if (Framework::current_event->keyboard.keycode == button_left_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_LEFT);
+	else if (Framework::current_event->keyboard.keycode == button_right_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_RIGHT);
+	else if (Framework::current_event->keyboard.keycode == button_start_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_START);
+	else if (Framework::current_event->keyboard.keycode == button_back_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_BACK);
+	else if (Framework::current_event->keyboard.keycode == button_a_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_A);
+	else if (Framework::current_event->keyboard.keycode == button_b_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_B);
+	else if (Framework::current_event->keyboard.keycode == button_c_keyboard_keymap) emit_gamer_button_down(GAMER_BUTTON_C);
 }
 
 
@@ -163,15 +163,15 @@ void GamerInputScreen::key_down_func()
 
 void GamerInputScreen::key_up_func()
 {
-	if (af::current_event->keyboard.keycode == button_up_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_UP);
-	else if (af::current_event->keyboard.keycode == button_down_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_DOWN);
-	else if (af::current_event->keyboard.keycode == button_left_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_LEFT);
-	else if (af::current_event->keyboard.keycode == button_right_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_RIGHT);
-	else if (af::current_event->keyboard.keycode == button_start_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_START);
-	else if (af::current_event->keyboard.keycode == button_back_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_BACK);
-	else if (af::current_event->keyboard.keycode == button_a_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_A);
-	else if (af::current_event->keyboard.keycode == button_b_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_B);
-	else if (af::current_event->keyboard.keycode == button_c_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_C);
+	if (Framework::current_event->keyboard.keycode == button_up_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_UP);
+	else if (Framework::current_event->keyboard.keycode == button_down_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_DOWN);
+	else if (Framework::current_event->keyboard.keycode == button_left_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_LEFT);
+	else if (Framework::current_event->keyboard.keycode == button_right_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_RIGHT);
+	else if (Framework::current_event->keyboard.keycode == button_start_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_START);
+	else if (Framework::current_event->keyboard.keycode == button_back_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_BACK);
+	else if (Framework::current_event->keyboard.keycode == button_a_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_A);
+	else if (Framework::current_event->keyboard.keycode == button_b_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_B);
+	else if (Framework::current_event->keyboard.keycode == button_c_keyboard_keymap) emit_gamer_button_up(GAMER_BUTTON_C);
 }
 
 
@@ -179,9 +179,9 @@ void GamerInputScreen::key_up_func()
 
 void GamerInputScreen::joy_axis_func()
 {
-	float pos = af::current_event->joystick.pos;
+	float pos = Framework::current_event->joystick.pos;
 
-	if (af::current_event->joystick.axis == 0) // left-right
+	if (Framework::current_event->joystick.axis == 0) // left-right
 	{
 		if (fabs(pos) < 0.5)
 		{
@@ -200,7 +200,7 @@ void GamerInputScreen::joy_axis_func()
 			if (!pressed[GAMER_BUTTON_RIGHT]) emit_gamer_button_down(GAMER_BUTTON_RIGHT);
 		}
 	}
-	if (af::current_event->joystick.axis == 1) // up-down
+	if (Framework::current_event->joystick.axis == 1) // up-down
 	{
 		if (fabs(pos) < 0.5)
 		{
@@ -226,15 +226,15 @@ void GamerInputScreen::joy_axis_func()
 
 void GamerInputScreen::joy_button_down_func()
 {
-	if (af::current_event->joystick.button == button_up_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_UP);
-	else if (af::current_event->joystick.button == button_down_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_DOWN);
-	else if (af::current_event->joystick.button == button_left_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_LEFT);
-	else if (af::current_event->joystick.button == button_right_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_RIGHT);
-	else if (af::current_event->joystick.button == button_start_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_START);
-	else if (af::current_event->joystick.button == button_back_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_BACK);
-	else if (af::current_event->joystick.button == button_a_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_A);
-	else if (af::current_event->joystick.button == button_b_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_B);
-	else if (af::current_event->joystick.button == button_c_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_C);
+	if (Framework::current_event->joystick.button == button_up_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_UP);
+	else if (Framework::current_event->joystick.button == button_down_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_DOWN);
+	else if (Framework::current_event->joystick.button == button_left_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_LEFT);
+	else if (Framework::current_event->joystick.button == button_right_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_RIGHT);
+	else if (Framework::current_event->joystick.button == button_start_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_START);
+	else if (Framework::current_event->joystick.button == button_back_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_BACK);
+	else if (Framework::current_event->joystick.button == button_a_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_A);
+	else if (Framework::current_event->joystick.button == button_b_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_B);
+	else if (Framework::current_event->joystick.button == button_c_joystick_buttonmap) emit_gamer_button_down(GAMER_BUTTON_C);
 }
 
 
@@ -242,15 +242,15 @@ void GamerInputScreen::joy_button_down_func()
 
 void GamerInputScreen::joy_button_up_func()
 {
-	if (af::current_event->joystick.button == button_up_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_UP);
-	else if (af::current_event->joystick.button == button_down_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_DOWN);
-	else if (af::current_event->joystick.button == button_left_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_LEFT);
-	else if (af::current_event->joystick.button == button_right_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_RIGHT);
-	else if (af::current_event->joystick.button == button_start_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_START);
-	else if (af::current_event->joystick.button == button_back_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_BACK);
-	else if (af::current_event->joystick.button == button_a_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_A);
-	else if (af::current_event->joystick.button == button_b_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_B);
-	else if (af::current_event->joystick.button == button_c_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_C);
+	if (Framework::current_event->joystick.button == button_up_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_UP);
+	else if (Framework::current_event->joystick.button == button_down_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_DOWN);
+	else if (Framework::current_event->joystick.button == button_left_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_LEFT);
+	else if (Framework::current_event->joystick.button == button_right_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_RIGHT);
+	else if (Framework::current_event->joystick.button == button_start_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_START);
+	else if (Framework::current_event->joystick.button == button_back_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_BACK);
+	else if (Framework::current_event->joystick.button == button_a_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_A);
+	else if (Framework::current_event->joystick.button == button_b_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_B);
+	else if (Framework::current_event->joystick.button == button_c_joystick_buttonmap) emit_gamer_button_up(GAMER_BUTTON_C);
 }
 
 
@@ -259,7 +259,7 @@ void GamerInputScreen::joy_button_up_func()
 void GamerInputScreen::draw_gamer_input_state(bool button[GAMER_BUTTON_SIZE_MAX], float opacity, float x, float y, float align_x, float align_y, float scale_x, float scale_y)
 {
 	// get the controller bmp
-	ALLEGRO_BITMAP *controller = af::bitmaps["game_controller.png"];
+	ALLEGRO_BITMAP *controller = Framework::bitmaps["game_controller.png"];
 
 	// store the state and use a new transform
 	ALLEGRO_STATE prev_state;

--- a/source/screens/gamer_input_screen.cpp
+++ b/source/screens/gamer_input_screen.cpp
@@ -259,7 +259,7 @@ void GamerInputScreen::joy_button_up_func()
 void GamerInputScreen::draw_gamer_input_state(bool button[GAMER_BUTTON_SIZE_MAX], float opacity, float x, float y, float align_x, float align_y, float scale_x, float scale_y)
 {
 	// get the controller bmp
-	ALLEGRO_BITMAP *controller = Framework::bitmaps["game_controller.png"];
+	ALLEGRO_BITMAP *controller = Framework::bitmap("game_controller.png");
 
 	// store the state and use a new transform
 	ALLEGRO_STATE prev_state;

--- a/source/screens/simple_notification_screen.cpp
+++ b/source/screens/simple_notification_screen.cpp
@@ -69,7 +69,7 @@ SimpleNotificationScreen::SimpleNotificationScreen(Display *display, ALLEGRO_FON
 
 void SimpleNotificationScreen::primary_timer_func()
 {
-	motion.update(af::time_now);
+	motion.update(Framework::time_now);
 
 	float x_cursor = display->width()-20;
 	float y_cursor = display->height()-20;


### PR DESCRIPTION
A lot of stuff happens in this PR, the main purpose is to fix #30, which involved a lot of refactoring.  Here are the refactors/changes:

1. `af` has been renamed to `Framework` - Fixes https://github.com/MarkOates/allegro_flare/issues/17
2. Keyboard no longer hijacked in OSX - Fixes https://github.com/MarkOates/allegro_flare/issues/30
3. Global `Bin` objects (`samples`, `fonts`, `bitmaps`) are no longer directly accessible.  To grab assets, now use `Framework::bitmap('name')`, `Framework::font('name')`, `Framework::sample('name')`, `Framework::model('name')`
4. A reference to the `Motion` object can be obtained through `Framework::motion()`.  This is not an ideal solution and is just a temporary fix until a better option comes up.
5. `Framework` now has a singleton instance and some static members as well.
6. `Bin` objects can no longer be created in the global namespace.  Calling `al_init()` before `main()` is entered is bad news bears on OSX.

Note: In general, no anything should be constructed before `main()`. Like, ever. There may still be a few objects that do and in that case move them to `Framework::initialize()` if there aren't better options.