### PR TITLE
Rename ModelNew to Model3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Some Examples of Features and Tools
 - 2D path shapes (`path2d`)
 - 2D and 3D positioning tools (`vec2d`, `vec3d`, `placement2d`, `placement3d`)
 - cameras (`Camera2D`, `Camera3D`)
-- 3D model loading (`Model`)
+- 3D model loading (`Model3D`)
 - Basic image manipulation (`gaussian_blur()`, `color_overlay()`, `trim()`, `color_curve()`, `invert()`, etc)
 - Image generation (`draw_wav_sample()`, `draw_histogram()`, `create_gradient_bitmap()`, etc)
 - Create music notation (`MusicNotation`)

--- a/examples/ex_model_viewer.cpp
+++ b/examples/ex_model_viewer.cpp
@@ -11,12 +11,12 @@ class Project : public Screen
 public:
 	Camera3D camera;
 	BitmapBin bitmaps;
-	ModelNew *model;
+	Model3D *model;
 
 	Project(Display *display)
 		: Screen(display)
 		, camera(vec3d(0, 0, -5), vec3d(0, 0, 1), vec3d(0, 1, 0))
-		, model(new ModelNew())
+		, model(new Model3D())
 	{
 		model->load_obj_file("data/models/heart_item-01.obj");
 		model->set_texture(bitmaps["heart_item-02.png"]);

--- a/include/allegro_flare/bins/model_bin.h
+++ b/include/allegro_flare/bins/model_bin.h
@@ -13,13 +13,13 @@
 
 
 
-class ModelBin : public Bin<ModelNew *>
+class ModelBin : public Bin<Model3D *>
 {
 public:
 	ModelBin(std::string directory="data/models");
 	~ModelBin();
-	ModelNew *load_data(std::string identifier);
-	void destroy_data(ModelNew *bmp);
+	Model3D *load_data(std::string identifier);
+	void destroy_data(Model3D *bmp);
 };
 
 

--- a/include/allegro_flare/framework.h
+++ b/include/allegro_flare/framework.h
@@ -54,7 +54,7 @@ public:
    static ALLEGRO_FONT *font(std::string identifier);
    static ALLEGRO_BITMAP *bitmap(std::string identifier);
    static ALLEGRO_SAMPLE *sample(std::string identifier);
-   static ModelNew *model(std::string identifier);
+   static Model3D *model(std::string identifier);
    static Motion &motion(); // we'll do this for now
 
 	static bool initialize(std::string config_filename="");

--- a/include/allegro_flare/model.h
+++ b/include/allegro_flare/model.h
@@ -1,5 +1,5 @@
-#ifndef __AF_MODEL_HEADER
-#define __AF_MODEL_HEADER
+#ifndef __AF_MODEL_3D_HEADER
+#define __AF_MODEL_3D_HEADER
 
 
 
@@ -23,7 +23,7 @@ typedef struct
 
 
 
-class ModelNew
+class Model3D
 {
 public:
 	struct named_object
@@ -49,7 +49,7 @@ public:
 	ALLEGRO_BITMAP *texture;
 	std::vector<named_object> named_objects; // < this is not very effecient, vector in a vector. Fix later.
 
-	ModelNew();
+	Model3D();
 	bool load_obj_file(const char *filename, float scale=1.0);
 	void inspect();
 	int get_num_vertexes();

--- a/source/bins/model_bin.cpp
+++ b/source/bins/model_bin.cpp
@@ -10,7 +10,7 @@
 
 
 ModelBin::ModelBin(std::string directory)
-	: Bin<ModelNew *>(directory)
+	: Bin<Model3D *>(directory)
 {}
 
 
@@ -24,9 +24,9 @@ ModelBin::~ModelBin()
 
 
 
-ModelNew *ModelBin::load_data(std::string identifier)
+Model3D *ModelBin::load_data(std::string identifier)
 {
-	ModelNew *m = new ModelNew();
+	Model3D *m = new Model3D();
 	if (m->load_obj_file(identifier.c_str(), 1.0f)) return m;
 	delete m;
 	return NULL;
@@ -35,7 +35,7 @@ ModelNew *ModelBin::load_data(std::string identifier)
 
 
 
-void ModelBin::destroy_data(ModelNew *mdl)
+void ModelBin::destroy_data(Model3D *mdl)
 {
 	if (!mdl) return;
 	delete mdl;

--- a/source/framework.cpp
+++ b/source/framework.cpp
@@ -53,7 +53,7 @@ ALLEGRO_SAMPLE *Framework::sample(std::string identifier)
 
 
 
-ModelNew *Framework::model(std::string identifier)
+Model3D *Framework::model(std::string identifier)
 {
    return get_instance()->models[identifier];
 }

--- a/source/model.cpp
+++ b/source/model.cpp
@@ -14,7 +14,7 @@
 
 
 
-ModelNew::ModelNew()
+Model3D::Model3D()
 	: vertex_declaration(NULL)
 	, vertexes()
 	, texture(NULL)
@@ -32,7 +32,7 @@ ModelNew::ModelNew()
 
 
 
-bool ModelNew::load_obj_file(const char *filename, float scale)
+bool Model3D::load_obj_file(const char *filename, float scale)
 {
 	vertexes.clear();
 
@@ -47,7 +47,7 @@ bool ModelNew::load_obj_file(const char *filename, float scale)
 	vec3d vt_normal;
 	bool vertex_textures_found = false;
 	bool vertex_normals_found = false;
-	ModelNew::named_object *current_named_object = NULL;
+	Model3D::named_object *current_named_object = NULL;
 
 	if (!al_filename_exists(filename))
       std::cout << CONSOLE_COLOR_RED << "Could not load \"" << filename << "\" when creating Model3D" << CONSOLE_COLOR_DEFAULT << std::endl;
@@ -216,7 +216,7 @@ bool ModelNew::load_obj_file(const char *filename, float scale)
 
 
 
-void ModelNew::inspect()
+void Model3D::inspect()
 {
 	for (unsigned i=0; i<vertexes.size(); i++)
 		printf("[%d] %f %f %f : %f %f : %f %f %f\n", i, vertexes[i].x, vertexes[i].y, vertexes[i].z, vertexes[i].u, vertexes[i].v, vertexes[i].nx, vertexes[i].ny, vertexes[i].nz);
@@ -224,21 +224,21 @@ void ModelNew::inspect()
 
 
 
-int ModelNew::get_num_vertexes()
+int Model3D::get_num_vertexes()
 {
 	return vertexes.size();
 }
 
 
 
-int ModelNew::get_num_named_objects()
+int Model3D::get_num_named_objects()
 {
 	return named_objects.size();
 }
 
 
 
-void ModelNew::draw()
+void Model3D::draw()
 {
 	if (vertexes.empty()) return;
 
@@ -259,7 +259,7 @@ void ModelNew::draw()
 
 
 
-bool ModelNew::draw_object(int index)
+bool Model3D::draw_object(int index)
 {
 	if (index < 0 || index > (int)named_objects.size()) return false;
 
@@ -274,7 +274,7 @@ bool ModelNew::draw_object(int index)
 
 
 
-bool ModelNew::draw_object(std::string name)
+bool Model3D::draw_object(std::string name)
 {
 	bool object_exists = false;
 	for (unsigned i=0; i<named_objects.size(); i++)
@@ -290,14 +290,14 @@ bool ModelNew::draw_object(std::string name)
 
 
 
-void ModelNew::set_texture(ALLEGRO_BITMAP *tx)
+void Model3D::set_texture(ALLEGRO_BITMAP *tx)
 {
 	texture = tx;
 }
 
 
 
-bool ModelNew::set_named_object_texture(int index, ALLEGRO_BITMAP *tx)
+bool Model3D::set_named_object_texture(int index, ALLEGRO_BITMAP *tx)
 {
 	if (index < 0 || index > (int)named_objects.size()) return false;
 	named_objects[index].texture = tx;
@@ -306,7 +306,7 @@ bool ModelNew::set_named_object_texture(int index, ALLEGRO_BITMAP *tx)
 
 
 
-bool ModelNew::set_named_object_texture(std::string object_name, ALLEGRO_BITMAP *tx)
+bool Model3D::set_named_object_texture(std::string object_name, ALLEGRO_BITMAP *tx)
 {
 	bool object_exists = false;
 	for (unsigned i=0; i<named_objects.size(); i++)
@@ -322,7 +322,7 @@ bool ModelNew::set_named_object_texture(std::string object_name, ALLEGRO_BITMAP 
 
 
 
-void ModelNew::scale(float scale)
+void Model3D::scale(float scale)
 {
 	for (unsigned i=0; i<vertexes.size(); i++)
 	{
@@ -334,7 +334,7 @@ void ModelNew::scale(float scale)
 
 
 
-vec3d ModelNew::get_min_vertex_coordinate()
+vec3d Model3D::get_min_vertex_coordinate()
 {
 	if (vertexes.empty()) return vec3d(0, 0, 0);
 
@@ -350,7 +350,7 @@ vec3d ModelNew::get_min_vertex_coordinate()
 
 
 
-vec3d ModelNew::get_max_vertex_coordinate()
+vec3d Model3D::get_max_vertex_coordinate()
 {
 	if (vertexes.empty()) return vec3d(0, 0, 0);
 


### PR DESCRIPTION
### History

When it was first created, it was called `Model`.  It was discovered that `Model` was _very_ inefficient when being drawn, and also lacked the all-important vertex normals needed for most shaders.

A `ModelNew` was created that was more ideal.  It drastically improved the way the model was drawn, both in appearance and performance.  For the most part, `ModelNew` just works (with [a few bugs](https://github.com/MarkOates/allegro_flare/issues/7)).  Although not ideally optimized, it is a huge step up from the bottleneck rendering design that was `Model`.  The complexities of how `ModelNew` can be optimized even further are best left for another discussion.

### This PR

This PR renames that `ModelNew` to `Model3D`.  The old name `Model` is not used because it could be confused with many other meanings (data model or model in a model-view-controller).

___
Fixes https://github.com/MarkOates/allegro_flare/issues/10