### PR TITLE
Add a Picking Buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BIN_ITEMS=font_bin sample_bin bitmap_bin model_bin
 DI_ITEMS=drawing_interface_allegro5 drawing_interface_html_canvas drawing_interface_svg
 FONT_ITEMS=font_bravura font_font_awesome font_segoe_ui_symbol
 SCREEN_ITEMS=simple_notification_screen gamer_input_screen filesys_change_notification_screen
-GUI_WIDGET_ITEMS=style_assets button checkbox dial draggable_region family float_spinner framed_window image int_spinner labeled_checkbox list_spinner music_notation progress_bar scaled_text scroll_area scrollbar slider spinner surface_area text text_area text_box text_input text_list toggle_button widget gui_screen window xy_controller
+GUI_WIDGET_ITEMS=style_assets button checkbox dial draggable_region family float_spinner framed_window image int_spinner labeled_checkbox list_spinner music_notation picking_buffer progress_bar scaled_text scroll_area scrollbar slider spinner surface_area text text_area text_box text_input text_list toggle_button widget gui_screen window xy_controller
 GUI_SURFACE_AREA_ITEMS=bitmap box box_padded circle column row
 
 CORE_OBJ_FILES=$(CORE_ITEMS:%=obj/%.o)

--- a/examples/gui/ex_picking_buffer.cpp
+++ b/examples/gui/ex_picking_buffer.cpp
@@ -1,0 +1,80 @@
+
+
+
+#include <allegro_flare/allegro_flare.h>
+
+
+#define SCREEN_W (1920/3*2)
+#define SCREEN_H (1080/3*2)
+
+
+class Project : public UIScreen
+{
+public:
+   UIPickingBuffer *picking_buffer;
+   UIButton *refresh_button;
+   UIButton *toggle_picking_buffer_visibility_button;
+   UIText *info_message;
+
+   Project(Display *display)
+      : UIScreen(display)
+      , picking_buffer(new UIPickingBuffer(this, SCREEN_W/2, SCREEN_H/2, SCREEN_W/3, SCREEN_H/3, 0))
+      , refresh_button(new UIButton(this, SCREEN_W/2 - 100, SCREEN_H/4*3, 120, 60, "Refresh"))
+      , toggle_picking_buffer_visibility_button(new UIButton(this, SCREEN_W/2 + 100, SCREEN_H/4*3, 120, 60, "Hide"))
+      , info_message(new UIText(this, SCREEN_W/2, SCREEN_H/4, ""))
+   {
+      draw_new_ids();
+   }
+   void draw_new_ids()
+   {
+      picking_buffer->clear_surface();
+
+      ALLEGRO_STATE previous_state;
+      al_store_state(&previous_state, ALLEGRO_STATE_TARGET_BITMAP);
+      al_set_target_bitmap(picking_buffer->surface_render);
+
+      for (unsigned i=0; i<10; i++)
+      {
+         float x = random_int(0, picking_buffer->place.size.x);
+         float y = random_int(0, picking_buffer->place.size.y);
+         float r = random_float(10, 30);
+         float id = random_int(1, 100);
+
+         al_draw_filled_circle(x, y, r, UIPickingBuffer::encode_id(id));
+      }
+
+      al_restore_state(&previous_state);
+   }
+   void on_message(UIWidget *sender, std::string message) override
+   {
+      if (sender == refresh_button)
+      {
+         draw_new_ids();
+      }
+      else if (sender == toggle_picking_buffer_visibility_button)
+      {
+         picking_buffer->draw_surface_render = !picking_buffer->draw_surface_render;
+         toggle_picking_buffer_visibility_button->set_text(picking_buffer->draw_surface_render ? "Hide" : "Show");
+      }
+      else if (sender == picking_buffer)
+      {
+         if (picking_buffer->is_on_click_id_message(message))
+         {
+            int id = picking_buffer->extract_on_click_id(message);
+            info_message->set_text(tostring("You clicked on ID #") + tostring(id));
+         }
+      }
+   }
+};
+
+
+int main(int argc, char **argv)
+{
+   Framework::initialize();
+   Display *display = Framework::create_display(SCREEN_W, SCREEN_H);
+   Project project = Project(display);
+   Framework::run_loop();
+   return 0;
+}
+
+

--- a/include/allegro_flare/gui.h
+++ b/include/allegro_flare/gui.h
@@ -26,6 +26,7 @@
 #include <allegro_flare/gui/widgets/list_spinner.h>
 #include <allegro_flare/gui/widgets/labeled_checkbox.h>
 #include <allegro_flare/gui/widgets/music_notation.h>
+#include <allegro_flare/gui/widgets/picking_buffer.h>
 #include <allegro_flare/gui/widgets/progress_bar.h>
 #include <allegro_flare/gui/widgets/scaled_text.h>
 #include <allegro_flare/gui/widgets/scroll_area.h>

--- a/include/allegro_flare/gui/widgets/picking_buffer.h
+++ b/include/allegro_flare/gui/widgets/picking_buffer.h
@@ -17,6 +17,7 @@ public:
    bool draw_surface_render;
 
    UIPickingBuffer(UIWidget *parent, float x, float y, int w, int h, int depth);
+   void create_new_surface(int w, int h, int depth);
    void clear_surface();
    void on_mouse_move(float x, float y, float dx, float dy) override;
    void on_click() override;

--- a/include/allegro_flare/gui/widgets/picking_buffer.h
+++ b/include/allegro_flare/gui/widgets/picking_buffer.h
@@ -24,6 +24,13 @@ public:
 
    static int decode_id(ALLEGRO_COLOR color);
    static ALLEGRO_COLOR encode_id(int id);
+
+   static std::string compose_on_click_id_message(int id);
+   static int extract_on_click_id(std::string message);
+   static bool is_on_click_id_message(std::string message);
+
+private:
+   static std::string MESSAGE_HEADER;
 };
 
 

--- a/include/allegro_flare/gui/widgets/picking_buffer.h
+++ b/include/allegro_flare/gui/widgets/picking_buffer.h
@@ -1,0 +1,29 @@
+#ifndef __AF_UI_PICKING_BUFFER_HEADER
+#define __AF_UI_PICKING_BUFFER_HEADER
+
+
+
+#include <allegro_flare/gui/widget.h>
+
+
+class UIPickingBuffer : public UIWidget
+{
+public:
+   ALLEGRO_BITMAP *surface_render;
+   int mouse_x, mouse_y;
+   int depth;
+   bool draw_surface_render;
+
+   UIPickingBuffer(UIWidget *parent, float x, float y, int w, int h, int depth);
+   void clear_surface();
+   void on_mouse_move(float x, float y, float dx, float dy) override;
+   void on_click() override;
+   void on_draw() override;
+
+   static int decode_id(ALLEGRO_COLOR color);
+   static ALLEGRO_COLOR encode_id(int id);
+};
+
+
+
+#endif

--- a/include/allegro_flare/gui/widgets/picking_buffer.h
+++ b/include/allegro_flare/gui/widgets/picking_buffer.h
@@ -9,6 +9,8 @@
 class UIPickingBuffer : public UIWidget
 {
 public:
+   static const int ID_MAX = 16777216;
+
    ALLEGRO_BITMAP *surface_render;
    int mouse_x, mouse_y;
    int depth;

--- a/source/gui/picking_buffer.cpp
+++ b/source/gui/picking_buffer.cpp
@@ -18,11 +18,7 @@ UIPickingBuffer::UIPickingBuffer(UIWidget *parent, float x, float y, int w, int 
    , mouse_y(0)
    , draw_surface_render(true)
 {
-   int previous_depth = al_get_new_bitmap_depth();
-   al_set_new_bitmap_depth(depth);
-   surface_render = al_create_bitmap(place.size.x, place.size.y);
-   al_set_new_bitmap_depth(previous_depth);
-
+   create_new_surface(place.size.x, place.size.y, depth);
    clear_surface();
 }
 
@@ -30,6 +26,27 @@ UIPickingBuffer::UIPickingBuffer(UIWidget *parent, float x, float y, int w, int 
 
 
 std::string UIPickingBuffer::MESSAGE_HEADER = "on_click_id ";
+
+
+
+
+void UIPickingBuffer::create_new_surface(int w, int h, int depth)
+{
+   if (surface_render) al_destroy_bitmap(surface_render);
+
+   int previous_depth = al_get_new_bitmap_depth();
+   int previous_samples = al_get_new_bitmap_samples();
+   ALLEGRO_STATE previous_state;
+   al_store_state(&previous_state, ALLEGRO_STATE_BITMAP);
+
+   al_set_new_bitmap_depth(depth);
+   al_set_new_bitmap_samples(0);
+   surface_render = al_create_bitmap(w, h);
+
+   al_restore_state(&previous_state);
+   al_set_new_bitmap_depth(previous_depth);
+   al_set_new_bitmap_samples(previous_samples);
+}
 
 
 

--- a/source/gui/picking_buffer.cpp
+++ b/source/gui/picking_buffer.cpp
@@ -29,6 +29,11 @@ UIPickingBuffer::UIPickingBuffer(UIWidget *parent, float x, float y, int w, int 
 
 
 
+std::string UIPickingBuffer::MESSAGE_HEADER = "on_click_id ";
+
+
+
+
 void UIPickingBuffer::clear_surface()
 {
    ALLEGRO_STATE state;
@@ -59,8 +64,7 @@ void UIPickingBuffer::on_click()
       if (mouse_y < 0 || mouse_y > al_get_bitmap_height(surface_render)) return;
 
       int clicked_id = decode_id(al_get_pixel(surface_render, mouse_x, mouse_y));
-      // TODO: improve message to include ID
-      send_message_to_parent("on_click_id()");
+      send_message_to_parent(UIPickingBuffer::compose_on_click_id_message(clicked_id));
    }
 }
 
@@ -100,6 +104,38 @@ ALLEGRO_COLOR UIPickingBuffer::encode_id(int id)
 
    return al_map_rgba(r, g, b, a);
 }
+
+
+
+
+std::string UIPickingBuffer::compose_on_click_id_message(int id)
+{
+   std::stringstream ss;
+   ss << MESSAGE_HEADER << id;
+   return ss.str();
+}
+
+
+
+
+int UIPickingBuffer::extract_on_click_id(std::string message)
+{
+   if (strncmp(message.c_str(), MESSAGE_HEADER.c_str(), MESSAGE_HEADER.size()) == 0)
+   {
+      int extracted_id = atoi(message.substr(MESSAGE_HEADER.size()).c_str());
+      return extracted_id;
+   }
+   return 0;
+}
+
+
+
+
+bool UIPickingBuffer::is_on_click_id_message(std::string message)
+{
+   return strncmp(message.c_str(), MESSAGE_HEADER.c_str(), MESSAGE_HEADER.size()) == 0;
+}
+
 
 
 

--- a/source/gui/picking_buffer.cpp
+++ b/source/gui/picking_buffer.cpp
@@ -83,7 +83,8 @@ int UIPickingBuffer::decode_id(ALLEGRO_COLOR color)
 {
    unsigned char r, g, b, a;
    al_unmap_rgba(color, &r, &g, &b, &a);
-   return r * 256 + g;
+
+   return r + (g * 256) + (b * 65536);
 }
 
 
@@ -92,9 +93,12 @@ int UIPickingBuffer::decode_id(ALLEGRO_COLOR color)
 ALLEGRO_COLOR UIPickingBuffer::encode_id(int id)
 {
    ALLEGRO_COLOR color;
-   unsigned char r = id / 256;
-   unsigned char g = id % 256;
-   return al_map_rgba(r, g, 0, 255);
+   unsigned char r = id % 256;
+   unsigned char g = id / 256;
+   unsigned char b = id / 65536;
+   unsigned char a = (id == 0) ? 0 : 255;
+
+   return al_map_rgba(r, g, b, a);
 }
 
 

--- a/tests/picking_buffer_test.cpp
+++ b/tests/picking_buffer_test.cpp
@@ -101,3 +101,34 @@ BOOST_FIXTURE_TEST_CASE(does_not_encode_negative_numbers, Setup)
    int encoded_num = UIPickingBuffer::decode_id(UIPickingBuffer::encode_id(-1));
    BOOST_CHECK_NE(-1, encoded_num);
 }
+
+
+BOOST_AUTO_TEST_CASE(builds_an_on_click_id_message)
+{
+   BOOST_CHECK_EQUAL("on_click_id 42", UIPickingBuffer::compose_on_click_id_message(42));
+   BOOST_CHECK_EQUAL("on_click_id 64", UIPickingBuffer::compose_on_click_id_message(64));
+   BOOST_CHECK_EQUAL("on_click_id 3", UIPickingBuffer::compose_on_click_id_message(3));
+}
+
+
+BOOST_AUTO_TEST_CASE(extracts_an_id_from_an_on_click_id_message)
+{
+   BOOST_CHECK_EQUAL(42, UIPickingBuffer::extract_on_click_id("on_click_id 42"));
+   BOOST_CHECK_EQUAL(64, UIPickingBuffer::extract_on_click_id("on_click_id 64"));
+   BOOST_CHECK_EQUAL(3, UIPickingBuffer::extract_on_click_id("on_click_id 3"));
+}
+
+
+BOOST_AUTO_TEST_CASE(identifies_a_properly_formatted_on_click_id_message)
+{
+   BOOST_CHECK_EQUAL(true, UIPickingBuffer::is_on_click_id_message("on_click_id 9"));
+   BOOST_CHECK_EQUAL(true, UIPickingBuffer::is_on_click_id_message("on_click_id 345678"));
+   BOOST_CHECK_EQUAL(true, UIPickingBuffer::is_on_click_id_message("on_click_id 42"));
+
+   BOOST_CHECK_EQUAL(false, UIPickingBuffer::is_on_click_id_message(""));
+   BOOST_CHECK_EQUAL(false, UIPickingBuffer::is_on_click_id_message("foo bar"));
+   BOOST_CHECK_EQUAL(false, UIPickingBuffer::is_on_click_id_message("on_click_id"));
+   BOOST_CHECK_EQUAL(false, UIPickingBuffer::is_on_click_id_message("on_click_id9"));
+}
+
+

--- a/tests/picking_buffer_test.cpp
+++ b/tests/picking_buffer_test.cpp
@@ -1,0 +1,103 @@
+
+
+#define BOOST_TEST_MODULE UIIDPicker
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+
+#include <allegro_flare/gui/widgets/picking_buffer.h>
+
+
+
+struct Setup
+{
+   Setup()
+   {
+      BOOST_REQUIRE_EQUAL(false, al_is_system_installed());
+      BOOST_REQUIRE_EQUAL(true, al_init());
+   }
+   ~Setup()
+   {
+      al_uninstall_system();
+   }
+};
+
+
+
+BOOST_FIXTURE_TEST_CASE(decodes_transparent_to_ID_0, Setup)
+{
+   ALLEGRO_COLOR color = al_map_rgba(0, 0, 0, 0);
+   int decoded_id = UIPickingBuffer::decode_id(color);
+
+   BOOST_CHECK_EQUAL(0, decoded_id);
+}
+
+
+BOOST_FIXTURE_TEST_CASE(encodes_ID_0_to_transparent, Setup)
+{
+   ALLEGRO_COLOR color = UIPickingBuffer::encode_id(0);
+
+   unsigned char r, g, b, a;
+   al_unmap_rgba(color, &r, &g, &b, &a);
+
+   BOOST_CHECK_EQUAL(0, r);
+   BOOST_CHECK_EQUAL(0, g);
+   BOOST_CHECK_EQUAL(0, b);
+   BOOST_CHECK_EQUAL(0, a);
+}
+
+
+BOOST_FIXTURE_TEST_CASE(encodes_IDs_greater_than_0_with_an_alpha_of_255__test_1, Setup)
+{
+   ALLEGRO_COLOR color = UIPickingBuffer::encode_id(1);
+
+   unsigned char r, g, b, a;
+   al_unmap_rgba(color, &r, &g, &b, &a);
+
+   BOOST_CHECK_EQUAL(255, a);
+}
+
+
+BOOST_FIXTURE_TEST_CASE(encodes_IDs_greater_than_0_with_an_alpha_of_255__test_2, Setup)
+{
+   for (unsigned i=1; i<1000; i++)
+   {
+      ALLEGRO_COLOR color = UIPickingBuffer::encode_id(i);
+      unsigned char r, g, b, a;
+      al_unmap_rgba(color, &r, &g, &b, &a);
+
+      BOOST_CHECK_EQUAL(255, a);
+   }
+}
+
+
+BOOST_FIXTURE_TEST_CASE(encodes_all_numbers_less_than_UIPickingBuffer_ID_MAX, Setup)
+{
+   for (int i=0; i<UIPickingBuffer::ID_MAX; i++)
+   {
+      int encoded_num = UIPickingBuffer::decode_id(UIPickingBuffer::encode_id(i));
+      BOOST_CHECK_EQUAL(i, encoded_num);
+   }
+}
+
+
+BOOST_FIXTURE_TEST_CASE(does_not_encode_numbers_greater_than_or_equal_to_UIPickingBuffer_ID_MAX, Setup)
+{
+   int encoded_num = 0;
+   int expected_num = 0;
+
+   encoded_num = UIPickingBuffer::decode_id(UIPickingBuffer::encode_id(UIPickingBuffer::ID_MAX));
+   expected_num = UIPickingBuffer::ID_MAX;
+   BOOST_CHECK_NE(expected_num, encoded_num);
+
+   encoded_num = UIPickingBuffer::decode_id(UIPickingBuffer::encode_id(UIPickingBuffer::ID_MAX+1));
+   expected_num = UIPickingBuffer::ID_MAX+1;
+   BOOST_CHECK_NE(expected_num, encoded_num);
+}
+
+
+BOOST_FIXTURE_TEST_CASE(does_not_encode_negative_numbers, Setup)
+{
+   int encoded_num = UIPickingBuffer::decode_id(UIPickingBuffer::encode_id(-1));
+   BOOST_CHECK_NE(-1, encoded_num);
+}


### PR DESCRIPTION
Color picking is a technique that draws objects using flat colors to an offscreen buffer so that they can later be identified as clicked on by a mouse cursor.

This PR adds a Picking Buffer UI Widget, similar to the one used in the [TINS 2016 entry](https://github.com/MarkOates/tins2016/blob/master/iteration1/navigation.hpp#L3-L56).

___
Fixes #48 