### PR TITLE
Use Underscore-Case in Interpolator Function Names

### DIFF
--- a/examples/ex_ray_casting.cpp
+++ b/examples/ex_ray_casting.cpp
@@ -1352,7 +1352,7 @@ public:
             {
                text_notification.set_text("Press 'R' to reload");
                text_notification.spawn();
-               motion.canimate(&gun_sprite.get_attr("y"), display->height()+8, display->height(), Framework::time_now, Framework::time_now+0.1, interpolator::doubleFastIn, NULL, NULL);  
+               motion.canimate(&gun_sprite.get_attr("y"), display->height()+8, display->height(), Framework::time_now, Framework::time_now+0.1, interpolator::double_fast_in, NULL, NULL);
             }
          }
          else
@@ -1361,7 +1361,7 @@ public:
             al_play_sample(samples["gunshot-01.wav"], 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
             bullets_in_magazine--;
             gun_fired = true;
-            motion.canimate(&gun_sprite.get_attr("y"), display->height()-16, display->height(), Framework::time_now, Framework::time_now+0.2, interpolator::doubleFastIn, NULL, NULL);  
+            motion.canimate(&gun_sprite.get_attr("y"), display->height()-16, display->height(), Framework::time_now, Framework::time_now+0.2, interpolator::double_fast_in, NULL, NULL);
          }
       }
    }
@@ -1895,7 +1895,7 @@ public:
                   if (player_picked_up_item)
                   {
                      depth_caches_z_sorted[x]->obj_entity->active = false;
-                     animate_color(&motion, &frame_color, item_color, color::black, Framework::time_now, pickup_frame_time_length, interpolator::fastIn);
+                     animate_color(&motion, &frame_color, item_color, color::black, Framework::time_now, pickup_frame_time_length, interpolator::fast_in);
                      text_notification.set_text(notification_text, TextNotification::STYLE_PICKUP_ITEM);
                      text_notification.background_color = item_color;
                      text_notification.spawn();

--- a/examples/gui/dev_clock_widget.cpp
+++ b/examples/gui/dev_clock_widget.cpp
@@ -120,8 +120,8 @@ void hide_clock(void *obj, ALLEGRO_MOUSE_EVENT *ev, void *user)
 
 void show_clock(void *obj, ALLEGRO_MOUSE_EVENT *ev, void *user)
 {
-   Framework::motion().cmove_to(&clock_opacity, 1.0, 0.3, interpolator::slowInOut);
-   Framework::motion().cmove_to(&clock_radius, max_clock_radius, 0.3, interpolator::slowInOut);
+   Framework::motion().cmove_to(&clock_opacity, 1.0, 0.3, interpolator::slow_in_out);
+   Framework::motion().cmove_to(&clock_radius, max_clock_radius, 0.3, interpolator::slow_in_out);
    if (clock_opacity == 0.0) al_play_sample(Framework::sample("clock_show.wav"), 1.0, 0.0, 1.0, ALLEGRO_PLAYMODE_ONCE, NULL);
 }
 

--- a/examples/gui/dev_console.cpp
+++ b/examples/gui/dev_console.cpp
@@ -131,15 +131,15 @@ public:
       if (active)
       {
          // hide
-         Framework::motion().canimate(&visibility_counter, visibility_counter, 0, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
-         Framework::motion().canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, -150, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion().canimate(&visibility_counter, visibility_counter, 0, Framework::time_now, Framework::time_now+0.2, interpolator::fast_in, NULL, NULL);
+         Framework::motion().canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, -150, Framework::time_now, Framework::time_now+0.2, interpolator::fast_in, NULL, NULL);
          text_input_widget->set_as_unfocused();
       }
       else
       {
          // show
-         Framework::motion().canimate(&visibility_counter, visibility_counter, 1, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
-         Framework::motion().canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, console_height-console_padding, Framework::time_now, Framework::time_now+0.2, interpolator::fastIn, NULL, NULL);
+         Framework::motion().canimate(&visibility_counter, visibility_counter, 1, Framework::time_now, Framework::time_now+0.2, interpolator::fast_in, NULL, NULL);
+         Framework::motion().canimate(&text_input_widget->place.position.y, text_input_widget->place.position.y, console_height-console_padding, Framework::time_now, Framework::time_now+0.2, interpolator::fast_in, NULL, NULL);
          text_input_widget->set_as_focused();
       }
 

--- a/examples/gui/dev_software_keyboard.cpp
+++ b/examples/gui/dev_software_keyboard.cpp
@@ -100,7 +100,7 @@ public:
    {
       ALLEGRO_COLOR key_color_now = is_standard_key ? key_color : alt_key_color;
       if (mouse_over) key_color_now = color::greenyellow;
-      if (pressed_counter > 0) key_color_now = color::mix(key_color_now, color::greenyellow, interpolator::trippleFastOut(pressed_counter));
+      if (pressed_counter > 0) key_color_now = color::mix(key_color_now, color::greenyellow, interpolator::tripple_fast_out(pressed_counter));
 
       //: is_standard_key ? key_color : alt_key_color;
       al_draw_filled_rectangle(x, y, x+w, y+h, key_color_now);
@@ -279,17 +279,17 @@ public:
       if (visible)
       {
          // hide
-         motion_manager.animate(&placement.position.y, placement.position.y, -display->height()/3*2.2, time_now, time_now+0.4, interpolator::quadrupleFastIn, NULL, NULL);
-         motion_manager.animate(&placement.scale.x, placement.scale.x, 0.7, time_now, time_now+0.4, interpolator::quadrupleFastIn, NULL, NULL);
-         motion_manager.animate(&placement.scale.y, placement.scale.y, 0.7, time_now, time_now+0.4, interpolator::quadrupleFastIn, NULL, NULL);
+         motion_manager.animate(&placement.position.y, placement.position.y, -display->height()/3*2.2, time_now, time_now+0.4, interpolator::quadruple_fast_in, NULL, NULL);
+         motion_manager.animate(&placement.scale.x, placement.scale.x, 0.7, time_now, time_now+0.4, interpolator::quadruple_fast_in, NULL, NULL);
+         motion_manager.animate(&placement.scale.y, placement.scale.y, 0.7, time_now, time_now+0.4, interpolator::quadruple_fast_in, NULL, NULL);
          for (int i=0; i<43; i++) key[i].mouse_over = false;
       }
       else
       {
          // show
-         motion_manager.animate(&placement.position.y, placement.position.y, -display->height()/2+h, time_now, time_now+0.4, interpolator::quadrupleFastIn, NULL, NULL);
-         motion_manager.animate(&placement.scale.x, placement.scale.x, 0.9, time_now, time_now+0.4, interpolator::quadrupleFastIn, NULL, NULL);
-         motion_manager.animate(&placement.scale.y, placement.scale.y, 0.9, time_now, time_now+0.4, interpolator::quadrupleFastIn, NULL, NULL);
+         motion_manager.animate(&placement.position.y, placement.position.y, -display->height()/2+h, time_now, time_now+0.4, interpolator::quadruple_fast_in, NULL, NULL);
+         motion_manager.animate(&placement.scale.x, placement.scale.x, 0.9, time_now, time_now+0.4, interpolator::quadruple_fast_in, NULL, NULL);
+         motion_manager.animate(&placement.scale.y, placement.scale.y, 0.9, time_now, time_now+0.4, interpolator::quadruple_fast_in, NULL, NULL);
          for (int i=0; i<43; i++) key[i].mouse_over = false;
       }
       */

--- a/include/allegro_flare/interpolators.h
+++ b/include/allegro_flare/interpolators.h
@@ -15,71 +15,71 @@ namespace interpolator
 
    float linear(float value);
 
-   float quadraticIn(float t);
-   float quadraticOut(float t);
-   float quadraticInOut(float t);
-   float quadraticOutIn(float t);
+   float quadratic_in(float t);
+   float quadratic_out(float t);
+   float quadratic_in_out(float t);
+   float quadratic_out_in(float t);
 
-   float cubicIn(float t);
-   float cubicOut(float t);
-   float cubicInOut(float t);
+   float cubic_in(float t);
+   float cubic_out(float t);
+   float cubic_in_out(float t);
 
-   float quarticIn(float t);
-   float quarticOut(float t);
-   float quarticInOut(float t);
+   float quartic_in(float t);
+   float quartic_out(float t);
+   float quartic_in_out(float t);
 
-   float quinticIn(float t);
-   float quinticOut(float t);
-   float quinticInOut(float t);
+   float quintic_in(float t);
+   float quintic_out(float t);
+   float quintic_in_out(float t);
 
-   float sineIn(float t);
-   float sineOut(float t);
-   float sineInOut(float t);
+   float sine_in(float t);
+   float sine_out(float t);
+   float sine_in_out(float t);
 
-   float exponentialIn(float t);
-   float exponentialOut(float t);
-   float exponentialInOut(float t);
+   float exponential_in(float t);
+   float exponential_out(float t);
+   float exponential_in_out(float t);
 
-   float circularIn(float t);
-   float circularOut(float t);
-   float circularInOut(float t);
+   float circular_in(float t);
+   float circular_out(float t);
+   float circular_in_out(float t);
 
-   float elasticIn(float t);
+   float elastic_in(float t);
 
-   float backIn(float t);
-   float backOut(float t);
-   float backInOut(float t);
+   float back_in(float t);
+   float back_out(float t);
+   float back_in_out(float t);
 
-   float bounceOut(float t);
-   float bounceIn(float t);
-   float bounceInOut(float t);
+   float bounce_out(float t);
+   float bounce_in(float t);
+   float bounce_in_out(float t);
 
-   float fastIn(float t);
-   float fastOut(float t);
-   float fastInOut(float t);
-   float slowIn(float t);
-   float slowOut(float t);
-   float slowInOut(float t);
+   float fast_in(float t);
+   float fast_out(float t);
+   float fast_in_out(float t);
+   float slow_in(float t);
+   float slow_out(float t);
+   float slow_in_out(float t);
 
-   float doubleFastIn(float t);
-   float doubleFastOut(float t);
-   float doubleSlowIn(float t);
-   float doubleSlowOut(float t);
-   float doubleSlowInOut(float t);
+   float double_fast_in(float t);
+   float double_fast_out(float t);
+   float double_slow_in(float t);
+   float double_slow_out(float t);
+   float double_slow_in_out(float t);
 
-   float trippleFastIn(float t);
-   float trippleFastOut(float t);
-   float trippleSlowIn(float t);
-   float trippleSlowOut(float t);
-   float trippleSlowInOut(float t);
+   float tripple_fast_in(float t);
+   float tripple_fast_out(float t);
+   float tripple_slow_in(float t);
+   float tripple_slow_out(float t);
+   float tripple_slow_in_out(float t);
 
-   float quadrupleFastIn(float t);
-   float quadrupleFastOut(float t);
-   float quadrupleSlowIn(float t);
-   float quadrupleSlowOut(float t);
-   float quadrupleSlowInOut(float t);
+   float quadruple_fast_in(float t);
+   float quadruple_fast_out(float t);
+   float quadruple_slow_in(float t);
+   float quadruple_slow_out(float t);
+   float quadruple_slow_in_out(float t);
 
-   float bloompIn(float value); // TODO: fix this broken function
+   float bloomp_in(float value); // TODO: fix this broken function
 
    interpolator_func_t get_interpolator_by_name(std::string name);
    std::string get_interpolator_func_name_as_str(interpolator_func_t func); // TODO: complete this function

--- a/include/allegro_flare/motion.h
+++ b/include/allegro_flare/motion.h
@@ -53,13 +53,13 @@ public:
 
    // simple motion
    void animate(float *val, float start_val, float end_val, float start_time, float end_time, float (*interpolator_func)(float), void (*callback_func)(void *), void *callback_data);
-   void move(float *val, float displacement, float duration=0.4, float (*interpolator_func)(float)=interpolator::fastIn, void (*callback_func)(void *)=NULL, void *callback_data=NULL);
-   void move_to(float *val, float dest_val, float duration=0.4, float (*interpolator_func)(float)=interpolator::fastIn, void (*callback_func)(void *)=NULL, void *callback_data=NULL);
+   void move(float *val, float displacement, float duration=0.4, float (*interpolator_func)(float)=interpolator::fast_in, void (*callback_func)(void *)=NULL, void *callback_data=NULL);
+   void move_to(float *val, float dest_val, float duration=0.4, float (*interpolator_func)(float)=interpolator::fast_in, void (*callback_func)(void *)=NULL, void *callback_data=NULL);
 
    // same as above, but clears any existing animations on *val beforehand.
    void canimate(float *val, float start_val, float end_val, float start_time, float end_time, float (*interpolator_func)(float), void (*callback_func)(void *), void *callback_data);
-   void cmove(float *val, float displacement, float duration=0.4, float (*interpolator_func)(float)=interpolator::fastIn, void (*callback_func)(void *)=NULL, void *callback_data=NULL);
-   void cmove_to(float *val, float dest_val, float duration=0.4, float (*interpolator_func)(float)=interpolator::fastIn, void (*callback_func)(void *)=NULL, void *callback_data=NULL);
+   void cmove(float *val, float displacement, float duration=0.4, float (*interpolator_func)(float)=interpolator::fast_in, void (*callback_func)(void *)=NULL, void *callback_data=NULL);
+   void cmove_to(float *val, float dest_val, float duration=0.4, float (*interpolator_func)(float)=interpolator::fast_in, void (*callback_func)(void *)=NULL, void *callback_data=NULL);
 };
 
 

--- a/source/gui/checkbox.cpp
+++ b/source/gui/checkbox.cpp
@@ -50,17 +50,17 @@ void UICheckbox::toggle()
    if (checked)
    {
       // check reveals
-      Framework::motion().cmove_to(&check_opacity, 1.0, speed * 0.5, interpolator::doubleFastIn);
-      Framework::motion().cmove_to(&check_placement.scale.x, 1.0, speed*0.85, interpolator::fastOut);
-      Framework::motion().cmove_to(&check_placement.scale.y, 1.0, speed*0.85, interpolator::fastOut);
-      Framework::motion().cmove_to(&check_placement.rotation, -0.1, speed, interpolator::fastOut);
+      Framework::motion().cmove_to(&check_opacity, 1.0, speed * 0.5, interpolator::double_fast_in);
+      Framework::motion().cmove_to(&check_placement.scale.x, 1.0, speed*0.85, interpolator::fast_out);
+      Framework::motion().cmove_to(&check_placement.scale.y, 1.0, speed*0.85, interpolator::fast_out);
+      Framework::motion().cmove_to(&check_placement.rotation, -0.1, speed, interpolator::fast_out);
    }
    else
    {
       // check removes
-      Framework::motion().cmove_to(&check_opacity, 0.0, speed, interpolator::doubleFastOut);
-      Framework::motion().cmove_to(&check_placement.scale.x, 0.0, speed, interpolator::slowIn);
-      Framework::motion().cmove_to(&check_placement.scale.y, 0.0, speed, interpolator::slowIn);
+      Framework::motion().cmove_to(&check_opacity, 0.0, speed, interpolator::double_fast_out);
+      Framework::motion().cmove_to(&check_placement.scale.x, 0.0, speed, interpolator::slow_in);
+      Framework::motion().cmove_to(&check_placement.scale.y, 0.0, speed, interpolator::slow_in);
       Framework::motion().cmove_to(&check_placement.rotation, -0.4, speed, interpolator::linear);
    }
 

--- a/source/gui/progress_bar.cpp
+++ b/source/gui/progress_bar.cpp
@@ -29,7 +29,7 @@ UIProgressBar::UIProgressBar(UIWidget *parent, float x, float y, float w, float 
 void UIProgressBar::set_val(float unit_val)
 {
    unit_val = limit<float>(0, 1, unit_val);
-   Framework::motion().cmove_to(&this->unit_val, unit_val, update_speed, interpolator::doubleFastIn);
+   Framework::motion().cmove_to(&this->unit_val, unit_val, update_speed, interpolator::double_fast_in);
 }
 
 

--- a/source/interpolators.cpp
+++ b/source/interpolators.cpp
@@ -47,9 +47,9 @@ float interpolator::linear(float value)
 // quadratic easing in - accelerating from zero velocity
 // t: current time, b: beginning value, c: change in value, d: duration
 // t and d can be in frames or seconds/milliseconds
-//A_INLINE float quadraticIn(float t)
+//A_INLINE float quadratic_in(float t)
 
-float interpolator::quadraticIn(float t)
+float interpolator::quadratic_in(float t)
 {
    return t*t;
 }
@@ -59,7 +59,7 @@ float interpolator::quadraticIn(float t)
 
 // quadratic easing out - decelerating to zero velocity
 
-float interpolator::quadraticOut(float t)
+float interpolator::quadratic_out(float t)
 {
    return -t*(t-2);
 }
@@ -69,7 +69,7 @@ float interpolator::quadraticOut(float t)
 
 // quadratic easing in/out - acceleration until halfway, then deceleration
 
-float interpolator::quadraticInOut(float t)
+float interpolator::quadratic_in_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -84,10 +84,10 @@ float interpolator::quadraticInOut(float t)
 
 // quadratic easing in/out - deceleration until halfway, then acceleration
 
-float interpolator::quadraticOutIn(float t)
+float interpolator::quadratic_out_in(float t)
 {
-   if (t < 0.5f) return quadraticOut(t*2) * 0.5f;
-   else if (t > 0.5f) return quadraticIn((t-0.5f)*2) * 0.5f + 0.5f;
+   if (t < 0.5f) return quadratic_out(t*2) * 0.5f;
+   else if (t > 0.5f) return quadratic_in((t-0.5f)*2) * 0.5f + 0.5f;
    else return t; // t == 0.5
 }
 
@@ -100,7 +100,7 @@ float interpolator::quadraticOutIn(float t)
 // t: current time, b: beginning value, c: change in value, d: duration
 // t and d can be frames or seconds/milliseconds
 
-float interpolator::cubicIn(float t)
+float interpolator::cubic_in(float t)
 {
    float b = 0;
    float c = 1;
@@ -113,7 +113,7 @@ float interpolator::cubicIn(float t)
 
 // cubic easing out - decelerating to zero velocity
 
-float interpolator::cubicOut(float t)
+float interpolator::cubic_out(float t)
 {
    t = t-1;
    return t*t*t + 1;
@@ -124,7 +124,7 @@ float interpolator::cubicOut(float t)
 
 // cubic easing in/out - acceleration until halfway, then deceleration
 
-float interpolator::cubicInOut(float t)
+float interpolator::cubic_in_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -144,7 +144,7 @@ float interpolator::cubicInOut(float t)
 // t: current time, b: beginning value, c: change in value, d: duration
 // t and d can be frames or seconds/milliseconds
 
-float interpolator::quarticIn(float t)
+float interpolator::quartic_in(float t)
 {
    float b = 0;
    float c = 1;
@@ -158,7 +158,7 @@ float interpolator::quarticIn(float t)
 
 // quartic easing out - decelerating to zero velocity
 
-float interpolator::quarticOut(float t)
+float interpolator::quartic_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -172,7 +172,7 @@ float interpolator::quarticOut(float t)
 
 // quartic easing in/out - acceleration until halfway, then deceleration
 
-float interpolator::quarticInOut(float t)
+float interpolator::quartic_in_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -191,7 +191,7 @@ float interpolator::quarticInOut(float t)
 // t: current time, b: beginning value, c: change in value, d: duration
 // t and d can be frames or seconds/milliseconds
 
-float interpolator::quinticIn(float t)
+float interpolator::quintic_in(float t)
 {
    float b = 0;
    float c = 1;
@@ -205,7 +205,7 @@ float interpolator::quinticIn(float t)
 
 // quintic easing out - decelerating to zero velocity
 
-float interpolator::quinticOut(float t)
+float interpolator::quintic_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -219,7 +219,7 @@ float interpolator::quinticOut(float t)
 
 // quintic easing in/out - acceleration until halfway, then deceleration
 
-float interpolator::quinticInOut(float t)
+float interpolator::quintic_in_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -241,7 +241,7 @@ float interpolator::quinticInOut(float t)
 // sinusoidal easing in - accelerating from zero velocity
 // t: current time, b: beginning value, c: change in position, d: duration
 
-float interpolator::sineIn(float t)
+float interpolator::sine_in(float t)
 {
    float b = 0.0f;
    float c = 1.0f;
@@ -254,7 +254,7 @@ float interpolator::sineIn(float t)
 
 // sinusoidal easing out - decelerating to zero velocity
 
-float interpolator::sineOut(float t)
+float interpolator::sine_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -267,7 +267,7 @@ float interpolator::sineOut(float t)
 
 // sinusoidal easing in/out - accelerating until halfway, then decelerating
 
-float interpolator::sineInOut(float t)
+float interpolator::sine_in_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -286,7 +286,7 @@ float interpolator::sineInOut(float t)
 // exponential easing in - accelerating from zero velocity
 // t: current time, b: beginning value, c: change in position, d: duration
 
-float interpolator::exponentialIn(float t)
+float interpolator::exponential_in(float t)
 {
    float b = 0;
    float c = 1;
@@ -299,7 +299,7 @@ float interpolator::exponentialIn(float t)
 
 // exponential easing out - decelerating to zero velocity
 
-float interpolator::exponentialOut(float t)
+float interpolator::exponential_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -312,7 +312,7 @@ float interpolator::exponentialOut(float t)
 
 // exponential easing in/out - accelerating until halfway, then decelerating
 
-float interpolator::exponentialInOut(float t)
+float interpolator::exponential_in_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -334,7 +334,7 @@ float interpolator::exponentialInOut(float t)
 // circular easing in - accelerating from zero velocity
 // t: current time, b: beginning value, c: change in position, d: duration
 
-float interpolator::circularIn(float t)
+float interpolator::circular_in(float t)
 {
    float b = 0;
    float c = 1;
@@ -348,7 +348,7 @@ float interpolator::circularIn(float t)
 
 // circular easing out - decelerating to zero velocity
 
-float interpolator::circularOut(float t)
+float interpolator::circular_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -362,7 +362,7 @@ float interpolator::circularOut(float t)
 
 // circular easing in/out - acceleration until halfway, then deceleration
 
-float interpolator::circularInOut(float t)
+float interpolator::circular_in_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -383,7 +383,7 @@ float interpolator::circularInOut(float t)
 // t: current time, b: beginning value, c: change in value, d: duration, a: amplitude (optional), p: period (optional)
 // t and d can be in frames or seconds/milliseconds
 
-float interpolator::elasticIn(float t)
+float interpolator::elastic_in(float t)
 {
    float amplitude = 1.0f; //<- not sure how modifying these variables will change things
    float period = 0.3f; //<- not sure how modifying these variables will change things
@@ -418,7 +418,7 @@ float interpolator::elasticIn(float t)
 // an OVERSHOOT value of 1.70158 produces an overshoot of 10%
 #define OVERSHOOT 1.70158f
 
-float interpolator::backIn(float t)
+float interpolator::back_in(float t)
 {
    float b = 0;
    float c = 1;
@@ -435,7 +435,7 @@ float interpolator::backIn(float t)
 
 // back easing out - moving towards target, overshooting it slightly, then reversing and coming back to target
 
-float interpolator::backOut(float t)
+float interpolator::back_out(float t)
 {
    float b = 0;
    float c = 1;
@@ -452,7 +452,7 @@ float interpolator::backOut(float t)
 // back easing in/out - backtracking slightly, then reversing direction and moving to target,
 // then overshooting target, reversing, and finally coming back to target
 
-float interpolator::backInOut(float t)
+float interpolator::back_in_out(float t)
 {
    float s = OVERSHOOT;
    if ((t) < 1) { t /= 0.5f; s*=(1.525f); return 0.5f*(t*t*(((s)+1)*t - s)); }
@@ -472,7 +472,7 @@ float interpolator::backInOut(float t)
 // t: current time, b: beginning value, c: change in position, d: duration
 // bounce easing out
 
-float interpolator::bounceOut(float t)
+float interpolator::bounce_out(float t)
 {
    if (t < (1.0f/2.75f)) return (7.5625f*t*t);
    else if (t < (2.0f/2.75f))
@@ -497,7 +497,7 @@ float interpolator::bounceOut(float t)
 
 // bounce easing in
 
-float interpolator::bounceIn(float t)
+float interpolator::bounce_in(float t)
 {
    t = 1.0f - t;
    if (t < (1.0f/2.75f)) return 1.0f - (7.5625f*t*t);
@@ -523,49 +523,49 @@ float interpolator::bounceIn(float t)
 
 // bounce easing in/out
 
-float interpolator::bounceInOut(float t)
+float interpolator::bounce_in_out(float t)
 {
-   if (t < 0.5f) return bounceIn(t*2.0f) * 0.5f;
-   return bounceOut(t*2.0f-1.0f) * 0.5f + 0.5f;
+   if (t < 0.5f) return bounce_in(t*2.0f) * 0.5f;
+   return bounce_out(t*2.0f-1.0f) * 0.5f + 0.5f;
 }
 
 
 
 
-float interpolator::fastIn(float t) { return quadraticOut(t); }
-float interpolator::fastOut(float t) { return quadraticIn(t); }
-float interpolator::fastInOut(float t) { return quadraticOutIn(t); }
-float interpolator::slowIn(float t) { return quadraticIn(t); }
-float interpolator::slowOut(float t) { return quadraticOut(t); }
-float interpolator::slowInOut(float t) { return quadraticInOut(t); }
+float interpolator::fast_in(float t) { return quadratic_out(t); }
+float interpolator::fast_out(float t) { return quadratic_in(t); }
+float interpolator::fast_in_out(float t) { return quadratic_out_in(t); }
+float interpolator::slow_in(float t) { return quadratic_in(t); }
+float interpolator::slow_out(float t) { return quadratic_out(t); }
+float interpolator::slow_in_out(float t) { return quadratic_in_out(t); }
 
-float interpolator::doubleFastIn(float t) { return cubicOut(t); }
-float interpolator::doubleFastOut(float t) { return cubicIn(t); }
-float interpolator::doubleSlowIn(float t) { return cubicIn(t); }
-float interpolator::doubleSlowOut(float t) { return cubicOut(t); }
-float interpolator::doubleSlowInOut(float t) { return cubicInOut(t); }
+float interpolator::double_fast_in(float t) { return cubic_out(t); }
+float interpolator::double_fast_out(float t) { return cubic_in(t); }
+float interpolator::double_slow_in(float t) { return cubic_in(t); }
+float interpolator::double_slow_out(float t) { return cubic_out(t); }
+float interpolator::double_slow_in_out(float t) { return cubic_in_out(t); }
 
-float interpolator::trippleFastIn(float t) { return quarticOut(t); }
-float interpolator::trippleFastOut(float t) { return quarticIn(t); }
-float interpolator::trippleSlowIn(float t) { return quarticIn(t); }
-float interpolator::trippleSlowOut(float t) { return quarticOut(t); }
-float interpolator::trippleSlowInOut(float t) { return quarticInOut(t); }
+float interpolator::tripple_fast_in(float t) { return quartic_out(t); }
+float interpolator::tripple_fast_out(float t) { return quartic_in(t); }
+float interpolator::tripple_slow_in(float t) { return quartic_in(t); }
+float interpolator::tripple_slow_out(float t) { return quartic_out(t); }
+float interpolator::tripple_slow_in_out(float t) { return quartic_in_out(t); }
 
-float interpolator::quadrupleFastIn(float t) { return quinticOut(t); }
-float interpolator::quadrupleFastOut(float t) { return quinticIn(t); }
-float interpolator::quadrupleSlowIn(float t) { return quinticIn(t); }
-float interpolator::quadrupleSlowOut(float t) { return quinticOut(t); }
-float interpolator::quadrupleSlowInOut(float t) { return quinticInOut(t); }
+float interpolator::quadruple_fast_in(float t) { return quintic_out(t); }
+float interpolator::quadruple_fast_out(float t) { return quintic_in(t); }
+float interpolator::quadruple_slow_in(float t) { return quintic_in(t); }
+float interpolator::quadruple_slow_out(float t) { return quintic_out(t); }
+float interpolator::quadruple_slow_in_out(float t) { return quintic_in_out(t); }
 
 
 
 
 // TODO: fix this thing
 
-float interpolator::bloompIn(float value)
+float interpolator::bloomp_in(float value)
 {
-#define fast_curve_interpolator(xxx, yyy, zzz) (fastIn((zzz-xxx)/(yyy-xxx))*(yyy-xxx) + xxx)
-#define slow_curve_interpolator(xxx, yyy, zzz) (slowIn((zzz-xxx)/(yyy-xxx))*(yyy-xxx) + xxx)
+#define fast_curve_interpolator(xxx, yyy, zzz) (fast_in((zzz-xxx)/(yyy-xxx))*(yyy-xxx) + xxx)
+#define slow_curve_interpolator(xxx, yyy, zzz) (slow_in((zzz-xxx)/(yyy-xxx))*(yyy-xxx) + xxx)
 
    float bounce_peak = 0.2f;
    //float &value = value;
@@ -588,7 +588,7 @@ float interpolator::bloompIn(float value)
    }
    else if (value >= 0.75f)
    {
-      float inner_value = slowInOut(value)*0.25f + 0.75f; //slow_inout_curve_interpolator(1.0f, 0.75f, value);
+      float inner_value = slow_in_out(value)*0.25f + 0.75f; //slow_inout_curve_interpolator(1.0f, 0.75f, value);
       return 1.0f - inner_value * bounce_peak * 0.4f; // bounce_peak is the total extra amount in the bounce
    }
    return value;
@@ -605,30 +605,30 @@ interpolator::interpolator_func_t interpolator::get_interpolator_by_name(std::st
    // incomplete
    if (name == "linear") return linear;
 
-   else if (name == "fastIn") return fastIn;
-   else if (name == "fastOut") return fastOut;
-   else if (name == "fastInOut") return fastInOut;
-   else if (name == "slowIn") return slowIn;
-   else if (name == "slowOut") return slowOut;
-   else if (name == "slowInOut") return slowInOut;
+   else if (name == "fast_in") return fast_in;
+   else if (name == "fast_out") return fast_out;
+   else if (name == "fast_in_out") return fast_in_out;
+   else if (name == "slow_in") return slow_in;
+   else if (name == "slow_out") return slow_out;
+   else if (name == "slow_in_out") return slow_in_out;
 
-   else if (name == "doubleFastIn") return doubleFastIn;
-   else if (name == "doubleFastOut") return doubleFastOut;
-   else if (name == "doubleSlowIn") return doubleSlowIn;
-   else if (name == "doubleSlowOut") return doubleSlowOut;
-   else if (name == "doubleSlowInOut") return doubleSlowInOut;
+   else if (name == "double_fast_in") return double_fast_in;
+   else if (name == "double_fast_out") return double_fast_out;
+   else if (name == "double_slow_in") return double_slow_in;
+   else if (name == "double_slow_out") return double_slow_out;
+   else if (name == "double_slow_in_out") return double_slow_in_out;
 
-   else if (name == "trippleFastIn") return trippleFastIn;
-   else if (name == "trippleFastOut") return trippleFastOut;
-   else if (name == "trippleSlowIn") return trippleSlowIn;
-   else if (name == "trippleSlowOut") return trippleSlowOut;
-   else if (name == "trippleSlowInOut") return trippleSlowInOut;
+   else if (name == "tripple_fast_in") return tripple_fast_in;
+   else if (name == "tripple_fast_out") return tripple_fast_out;
+   else if (name == "tripple_slow_in") return tripple_slow_in;
+   else if (name == "tripple_slow_out") return tripple_slow_out;
+   else if (name == "tripple_slow_in_out") return tripple_slow_in_out;
 
-   else if (name == "quadrupleFastIn") return quadrupleFastIn;
-   else if (name == "quadrupleFastOut") return quadrupleFastOut;
-   else if (name == "quadrupleSlowIn") return quadrupleSlowIn;
-   else if (name == "quadrupleSlowOut") return quadrupleSlowOut;
-   else if (name == "quadrupleSlowInOut") return quadrupleSlowInOut;
+   else if (name == "quadruple_fast_in") return quadruple_fast_in;
+   else if (name == "quadruple_fast_out") return quadruple_fast_out;
+   else if (name == "quadruple_slow_in") return quadruple_slow_in;
+   else if (name == "quadruple_slow_out") return quadruple_slow_out;
+   else if (name == "quadruple_slow_in_out") return quadruple_slow_in_out;
 
    return NULL;
 }
@@ -641,12 +641,12 @@ std::string interpolator::get_interpolator_func_name_as_str(interpolator::interp
    // incomplete
    if (func == linear) return "linear";
 
-   else if (func == fastIn) return "fastIn";
-   else if (func == fastOut) return "fastOut";
-   else if (func == fastInOut) return "fastInOut";
-   else if (func == slowIn) return "slowIn";
-   else if (func == slowOut) return "slowOut";
-   else if (func == slowInOut) return "slowInOut";
+   else if (func == fast_in) return "fast_in";
+   else if (func == fast_out) return "fast_out";
+   else if (func == fast_in_out) return "fast_in_out";
+   else if (func == slow_in) return "slow_in";
+   else if (func == slow_out) return "slow_out";
+   else if (func == slow_in_out) return "slow_in_out";
 
    return "undef";
 }

--- a/source/interpolators.cpp
+++ b/source/interpolators.cpp
@@ -33,21 +33,10 @@ float interpolator::linear(float value)
 
 
 
-///////////// LIBRARY EASING FUNCTIONS //////////////
-// the equations below come from http://robertpenner.com/easing/
+///////////// Quadratic Easing: t^2 ///////////////////
 
 
 
-
-///////////// QUADRATIC EASING: t^2 ///////////////////
-
-
-
-
-// quadratic easing in - accelerating from zero velocity
-// t: current time, b: beginning value, c: change in value, d: duration
-// t and d can be in frames or seconds/milliseconds
-//A_INLINE float quadratic_in(float t)
 
 float interpolator::quadratic_in(float t)
 {
@@ -57,8 +46,6 @@ float interpolator::quadratic_in(float t)
 
 
 
-// quadratic easing out - decelerating to zero velocity
-
 float interpolator::quadratic_out(float t)
 {
    return -t*(t-2);
@@ -66,8 +53,6 @@ float interpolator::quadratic_out(float t)
 
 
 
-
-// quadratic easing in/out - acceleration until halfway, then deceleration
 
 float interpolator::quadratic_in_out(float t)
 {
@@ -82,8 +67,6 @@ float interpolator::quadratic_in_out(float t)
 
 
 
-// quadratic easing in/out - deceleration until halfway, then acceleration
-
 float interpolator::quadratic_out_in(float t)
 {
    if (t < 0.5f) return quadratic_out(t*2) * 0.5f;
@@ -94,11 +77,10 @@ float interpolator::quadratic_out_in(float t)
 
 
 
-///////////// CUBIC EASING: t^3 ///////////////////////
+///////////// Cubic Easing: t^3 ///////////////////////
 
-// cubic easing in - accelerating from zero velocity
-// t: current time, b: beginning value, c: change in value, d: duration
-// t and d can be frames or seconds/milliseconds
+
+
 
 float interpolator::cubic_in(float t)
 {
@@ -111,8 +93,6 @@ float interpolator::cubic_in(float t)
 
 
 
-// cubic easing out - decelerating to zero velocity
-
 float interpolator::cubic_out(float t)
 {
    t = t-1;
@@ -121,8 +101,6 @@ float interpolator::cubic_out(float t)
 
 
 
-
-// cubic easing in/out - acceleration until halfway, then deceleration
 
 float interpolator::cubic_in_out(float t)
 {
@@ -138,11 +116,10 @@ float interpolator::cubic_in_out(float t)
 
 
 
-///////////// QUARTIC EASING: t^4 /////////////////////
+///////////// Quadratic Easing: t^4 /////////////////////
 
-// quartic easing in - accelerating from zero velocity
-// t: current time, b: beginning value, c: change in value, d: duration
-// t and d can be frames or seconds/milliseconds
+
+
 
 float interpolator::quartic_in(float t)
 {
@@ -156,8 +133,6 @@ float interpolator::quartic_in(float t)
 
 
 
-// quartic easing out - decelerating to zero velocity
-
 float interpolator::quartic_out(float t)
 {
    float b = 0;
@@ -169,8 +144,6 @@ float interpolator::quartic_out(float t)
 
 
 
-
-// quartic easing in/out - acceleration until halfway, then deceleration
 
 float interpolator::quartic_in_out(float t)
 {
@@ -185,11 +158,10 @@ float interpolator::quartic_in_out(float t)
 
 
 
-///////////// QUINTIC EASING: t^5  ////////////////////
+///////////// Quintic Easing: t^5 ////////////////////
 
-// quintic easing in - accelerating from zero velocity
-// t: current time, b: beginning value, c: change in value, d: duration
-// t and d can be frames or seconds/milliseconds
+
+
 
 float interpolator::quintic_in(float t)
 {
@@ -203,8 +175,6 @@ float interpolator::quintic_in(float t)
 
 
 
-// quintic easing out - decelerating to zero velocity
-
 float interpolator::quintic_out(float t)
 {
    float b = 0;
@@ -216,8 +186,6 @@ float interpolator::quintic_out(float t)
 
 
 
-
-// quintic easing in/out - acceleration until halfway, then deceleration
 
 float interpolator::quintic_in_out(float t)
 {
@@ -233,13 +201,10 @@ float interpolator::quintic_in_out(float t)
 
 
 
-///////////// SINUSOIDAL EASING: sin(t) ///////////////
+///////////// Sinusoidal Easing: sin(t) ///////////////
 
 
 
-
-// sinusoidal easing in - accelerating from zero velocity
-// t: current time, b: beginning value, c: change in position, d: duration
 
 float interpolator::sine_in(float t)
 {
@@ -252,8 +217,6 @@ float interpolator::sine_in(float t)
 
 
 
-// sinusoidal easing out - decelerating to zero velocity
-
 float interpolator::sine_out(float t)
 {
    float b = 0;
@@ -264,8 +227,6 @@ float interpolator::sine_out(float t)
 
 
 
-
-// sinusoidal easing in/out - accelerating until halfway, then decelerating
 
 float interpolator::sine_in_out(float t)
 {
@@ -278,13 +239,10 @@ float interpolator::sine_in_out(float t)
 
 
 
-///////////// EXPONENTIAL EASING: 2^t /////////////////
+///////////// Exponential Easing: 2^t /////////////////
 
 
 
-
-// exponential easing in - accelerating from zero velocity
-// t: current time, b: beginning value, c: change in position, d: duration
 
 float interpolator::exponential_in(float t)
 {
@@ -297,8 +255,6 @@ float interpolator::exponential_in(float t)
 
 
 
-// exponential easing out - decelerating to zero velocity
-
 float interpolator::exponential_out(float t)
 {
    float b = 0;
@@ -309,8 +265,6 @@ float interpolator::exponential_out(float t)
 
 
 
-
-// exponential easing in/out - accelerating until halfway, then decelerating
 
 float interpolator::exponential_in_out(float t)
 {
@@ -326,13 +280,10 @@ float interpolator::exponential_in_out(float t)
 
 
 
-/////////// CIRCULAR EASING: sqrt(1-t^2) //////////////
+/////////// Circular Easing: sqrt(1-t^2) //////////////
 
 
 
-
-// circular easing in - accelerating from zero velocity
-// t: current time, b: beginning value, c: change in position, d: duration
 
 float interpolator::circular_in(float t)
 {
@@ -346,8 +297,6 @@ float interpolator::circular_in(float t)
 
 
 
-// circular easing out - decelerating to zero velocity
-
 float interpolator::circular_out(float t)
 {
    float b = 0;
@@ -359,8 +308,6 @@ float interpolator::circular_out(float t)
 
 
 
-
-// circular easing in/out - acceleration until halfway, then deceleration
 
 float interpolator::circular_in_out(float t)
 {
@@ -375,13 +322,10 @@ float interpolator::circular_in_out(float t)
 
 
 
-/////////// ELASTIC EASING: exponentially decaying sine wave  //////////////
+/////////// Elastic Easing: Exponentially Decaying Sine Wave  //////////////
 
 
 
-
-// t: current time, b: beginning value, c: change in value, d: duration, a: amplitude (optional), p: period (optional)
-// t and d can be in frames or seconds/milliseconds
 
 float interpolator::elastic_in(float t)
 {
@@ -403,17 +347,10 @@ float interpolator::elastic_in(float t)
 
 
 
-/////////// BACK EASING: overshooting cubic easing: (s+1)*t^3 - s*t^2  //////////////
+/////////// Back Easing: Overshooting Cubic Easing: (s+1)*t^3 - s*t^2  //////////////
 
 
 
-
-// back easing in - backtracking slightly, then reversing direction and moving to target
-// t: current time, b: beginning value, c: change in value, d: duration, s: overshoot amount (optional)
-// t and d can be in frames or seconds/milliseconds
-// s controls the amount of overshoot: higher s means greater overshoot
-// s has a default value of 1.70158, which produces an overshoot of 10 percent
-// s==0 produces cubic easing with no overshoot
 
 // an OVERSHOOT value of 1.70158 produces an overshoot of 10%
 #define OVERSHOOT 1.70158f
@@ -433,8 +370,6 @@ float interpolator::back_in(float t)
 
 
 
-// back easing out - moving towards target, overshooting it slightly, then reversing and coming back to target
-
 float interpolator::back_out(float t)
 {
    float b = 0;
@@ -449,9 +384,6 @@ float interpolator::back_out(float t)
 
 
 
-// back easing in/out - backtracking slightly, then reversing direction and moving to target,
-// then overshooting target, reversing, and finally coming back to target
-
 float interpolator::back_in_out(float t)
 {
    float s = OVERSHOOT;
@@ -464,13 +396,10 @@ float interpolator::back_in_out(float t)
 
 
 
-/////////// BOUNCE EASING: exponentially decaying parabolic bounce  //////////////
+/////////// Bounce Easing: Exponentially Decaying Parabolic Bounce  //////////////
 
 
 
-
-// t: current time, b: beginning value, c: change in position, d: duration
-// bounce easing out
 
 float interpolator::bounce_out(float t)
 {
@@ -494,8 +423,6 @@ float interpolator::bounce_out(float t)
 
 
 
-
-// bounce easing in
 
 float interpolator::bounce_in(float t)
 {
@@ -521,13 +448,16 @@ float interpolator::bounce_in(float t)
 
 
 
-// bounce easing in/out
-
 float interpolator::bounce_in_out(float t)
 {
    if (t < 0.5f) return bounce_in(t*2.0f) * 0.5f;
    return bounce_out(t*2.0f-1.0f) * 0.5f + 0.5f;
 }
+
+
+
+
+/////////// User-Friendly Names //////////////
 
 
 


### PR DESCRIPTION
### Issues

Up until now, all `interpolator` functions have been CamelCase (e.g. `fastIn`, `slowInOut`, `trippleFastIn` etc.).  This is not in convention with anything else in AllegroFlare.

After this PR, names will be changed to underscore-case.

### Some Examples:

`fastIn` -> `fast_in`
`slowInOut` -> `slow_in_out`
`trippleFastIn` -> `tripple_fast_in`
`quadrupleSlowInOut` -> `quadruple_slow_in_out`

___
Fixes https://github.com/MarkOates/allegro_flare/issues/63