### PR TITLE
Fix Compile Warnings

### DIFF
--- a/src/framework/gui/gui_screen.cpp
+++ b/src/framework/gui/gui_screen.cpp
@@ -14,8 +14,8 @@ UIScreen::UIScreen(Display *display)
    : Screen(display)
    , UIWidget(NULL, "UIScreen", new UISurfaceAreaBox(0, 0, display->width(), display->height()))
    , draw_focused_outline(true)
-   , use_joystick_as_mouse(true)
    , focused_outline_color(color::dodgerblue)
+   , use_joystick_as_mouse(true)
 {
    surface_area->placement.align.x = 0;
    surface_area->placement.align.y = 0;

--- a/src/framework/gui/widgets/button.cpp
+++ b/src/framework/gui/widgets/button.cpp
@@ -18,10 +18,10 @@
 
 UIButton::UIButton(UIWidget *parent, float x, float y, float w, float h, std::string text)
    : UIWidget(parent, "UIButton", new UISurfaceAreaBox(x, y, w, h))
+   , icon(NULL)
+   , font(UIStyleAssets::get_ui_font())
    , text(text)
    , content_alignment(0.5)
-   , font(UIStyleAssets::get_ui_font())
-   , icon(NULL)
 {}
 
 

--- a/src/framework/gui/widgets/image.cpp
+++ b/src/framework/gui/widgets/image.cpp
@@ -12,8 +12,8 @@
 
 UIImage::UIImage(UIWidget *parent, float x, float y, ALLEGRO_BITMAP *_bitmap)
    : UIWidget(parent, "UIImage", new UISurfaceAreaBox(x, y, _bitmap ? al_get_bitmap_width(_bitmap) : 0, _bitmap ? al_get_bitmap_height(_bitmap) : 0))
-   , bitmap(_bitmap)
    , color(color::white)
+   , bitmap(_bitmap)
 {}
 
 

--- a/src/framework/gui/widgets/picking_buffer.cpp
+++ b/src/framework/gui/widgets/picking_buffer.cpp
@@ -116,7 +116,6 @@ int UIPickingBuffer::decode_id(ALLEGRO_COLOR color)
 
 ALLEGRO_COLOR UIPickingBuffer::encode_id(int id)
 {
-   ALLEGRO_COLOR color;
    unsigned char r = id % 256;
    unsigned char g = id / 256;
    unsigned char b = id / 65536;

--- a/src/framework/gui/widgets/scaled_text.cpp
+++ b/src/framework/gui/widgets/scaled_text.cpp
@@ -55,12 +55,12 @@ void UIScaledText::refresh_render()
 
 UIScaledText::UIScaledText(UIWidget *parent, float x, float y, std::string text)
    : UIWidget(parent, "UIScaledText", new UISurfaceAreaBox(x, y, 100, 100))
+   , render(NULL)
    , font_filename("DroidSans.ttf")
    , font_size(14)
    , render_scale(3.0)
-   , render(NULL)
-   , text(text)
    , font_color(color::white)
+   , text(text)
 {
    this->surface_area->placement.align.x = 0.0;
    this->no_focus = true;

--- a/src/framework/gui/widgets/scroll_area.cpp
+++ b/src/framework/gui/widgets/scroll_area.cpp
@@ -12,8 +12,8 @@
 
 UIScrollArea::UIScrollArea(UIWidget *parent, float x, float y, float w, float h, UIWidget *content_parent)
    : UIWidget(parent, "UIScrollArea", new UISurfaceAreaBox(x, y, w, h))
-   , canvas(content_parent)
    , v_slider(NULL)
+   , canvas(content_parent)
    , canvas_render(al_create_bitmap(w, h))
 {
    if (canvas) this->reassign_parent(canvas);

--- a/src/framework/gui/widgets/text_area.cpp
+++ b/src/framework/gui/widgets/text_area.cpp
@@ -97,10 +97,10 @@ bool UITextArea::Cursor::selection_active() { return head_pos != _anchor_pos; }
 
 UITextArea::UITextArea(UIWidget *parent, float x, float y, float w, float h, std::string text)
    : UIWidget(parent, "UITextArea", new UISurfaceAreaBox(x, y, w, h))
-   , cursor(0, 0)
    , full_text(text)
    , font(Framework::font("DroidSans.ttf 20"))
    , cursor_blink_counter(1)
+   , cursor(0, 0)
 {}
 
 

--- a/src/framework/gui/widgets/text_area.cpp
+++ b/src/framework/gui/widgets/text_area.cpp
@@ -223,8 +223,6 @@ void UITextArea::on_draw()
    float draw_cursor_y = PADDING;
    float text_bbox_width = place.size.x - PADDING * 2;
    std::string word;
-   std::size_t pos = 0;
-   std::size_t found_pos = 0;
    int _number_of_lines = 0;
 
    bool selection_active = cursor.selection_active();
@@ -417,7 +415,6 @@ void UITextArea::on_key_char()
 
    int unichar = Framework::current_event->keyboard.unichar;
    int keycode = Framework::current_event->keyboard.keycode;
-   int modifier = Framework::current_event->keyboard.modifiers;
 
    // test cut-copy-paste
    if ((keycode == ALLEGRO_KEY_C

--- a/src/framework/gui/widgets/text_box.cpp
+++ b/src/framework/gui/widgets/text_box.cpp
@@ -13,8 +13,8 @@
 UITextBox::UITextBox(UIWidget *parent, float x, float y, float w, float h, std::string text)
    : UIWidget(parent, "UITextBox", new UISurfaceAreaBox(x, y, w, h))
    , font(Framework::font("DroidSans.ttf 20"))
-   , text(text)
    , text_color(color::black)
+   , text(text)
 {
    no_focus = true;
 }

--- a/src/framework/gui/widgets/text_input.cpp
+++ b/src/framework/gui/widgets/text_input.cpp
@@ -402,7 +402,6 @@ void UITextInput::on_draw()
    if ((cursor_blink_counter-= 0.025) < 0) cursor_blink_counter = 1.0;
 
 
-   int full_len = al_get_text_width(font, text.c_str());
    int len_to_cursor = al_get_text_width(font, text.substr(0, cursor_pos).c_str());
    int len_to_cursor_end = len_to_cursor;
    if (cursor_end != cursor_pos) len_to_cursor_end = al_get_text_width(font, text.substr(0, cursor_end).c_str());

--- a/src/framework/gui/widgets/text_input.cpp
+++ b/src/framework/gui/widgets/text_input.cpp
@@ -19,13 +19,13 @@ UITextInput::UITextInput(UIWidget *parent, float x, float y, float w, float h, s
    , default_text_when_empty("")
    , cursor_pos(0)
    , cursor_end(0)
-   , font(Framework::font("DroidSans.ttf 20"))
    , cursor_blink_counter(0)
+   , font(Framework::font("DroidSans.ttf 20"))
    , text_x_offset(0)
    , font_color(color::white)
-   , _text_render(NULL)
    , padding(10)
    , select_all_on_focus(false)
+   , _text_render(NULL)
 {
    set_text(text);
 

--- a/src/framework/gui/widgets/text_list.cpp
+++ b/src/framework/gui/widgets/text_list.cpp
@@ -19,9 +19,10 @@ UIListItem::UIListItem() {};
 
 UITextList::UITextList(UIWidget *parent, float x, float y, float w)
    : UIWidget(parent, "UITextList", new UISurfaceAreaBox(x, y, w, 20))
-   , currently_selected_item(0)
    , item_padding(5)
    , item_height(20)
+   , currently_selected_item(0)
+   , items()
 {}
 
 

--- a/src/framework/gui/widgets/text_list.cpp
+++ b/src/framework/gui/widgets/text_list.cpp
@@ -102,7 +102,7 @@ float UITextList::get_item_height(int index)
 
 int UITextList::get_item_index_at(float x, float y)
 {
-   float padding_x = 16*2, padding_y = item_padding;
+   float padding_y = item_padding;
 
    // transform the coordin
    float cursor_y = padding_y;
@@ -190,9 +190,6 @@ void UITextList::draw_item(vec2d position, int index)
 
       float width = al_get_text_width(font, items[index].c_str());
       float height = al_get_font_line_height(font);
-
-      float text_center = position.x + width/2;
-      float text_middle = position.y + height/2;
 
       width += 22;
       height += 4;

--- a/src/framework/gui/widgets/widget.cpp
+++ b/src/framework/gui/widgets/widget.cpp
@@ -14,17 +14,17 @@
 UIWidget::UIWidget(UIWidget *parent, std::string widget_typename, UISurfaceAreaBase *surface_area)
    : ElementID(parent)
    , surface_area(surface_area)
-   , place(surface_area->placement)
-   , mouse_down_on_over(false)
    , mouse_over(false)
+   , mouse_down_on_over(false)
    , focused(false)
    , dragging(false)
    , no_focus(false)
-   , delete_me(false)
    , mouse_is_blocked(false)
    , local_mouse_x(0)
    , local_mouse_y(0)
    , disabled(false)
+   , delete_me(false)
+   , place(surface_area->placement)
 {
    set(UI_ATTR__UI_WIDGET_TYPE, widget_typename);
    set("id", widget_typename + tostring(widget_count));

--- a/src/framework/gui/widgets/xy_controller.cpp
+++ b/src/framework/gui/widgets/xy_controller.cpp
@@ -70,7 +70,6 @@ void UIXYController::on_draw()
    // draw the guides
    vec2d local_marker = vec2d(marker.x * place.size.x, marker.y * place.size.y);
 
-   ALLEGRO_COLOR guide_mixed_color = color::color(color::white, guide_opacity);
    al_draw_line(local_marker.x, 0, local_marker.x, place.size.y, color::color(color::white, guide_opacity), 1.0);
    al_draw_line(0, local_marker.y, place.size.x, local_marker.y, color::color(color::white, guide_opacity), 1.0);
 


### PR DESCRIPTION
### What's wrong

Since https://github.com/MarkOates/allegro_flare/pull/126, all obj files now build with `-Wall`, so there are some new warnings that need to be fixed.

### How was it fixed

There were only two warnings, `-Wreorder` and `-Wunused-variables`.  These were fixed in source.

### Why is this important

A compile without triggering warnings is a happy compile 😊 