### PR TITLE
Fix non virtual dtor errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ core: $(OBJECTS)
 
 obj/%.o: src/%.cpp | required_obj_dirs
 	@echo "compiling $< -> $@"
-	@g++ -c -std=gnu++11 -Wall $< -o $@ -I$(ALLEGRO_FLARE_DIR)/include -I$(ALLEGRO_DIR)/include -I./include
+	@g++ -c -Wnon-virtual-dtor -std=gnu++11 -Wall $< -o $@ -I$(ALLEGRO_FLARE_DIR)/include -I$(ALLEGRO_DIR)/include -I./include
 
 required_obj_dirs:
 	@echo "creating required directories"

--- a/include/allegro_flare/automation.h
+++ b/include/allegro_flare/automation.h
@@ -81,6 +81,8 @@ namespace automation
       ALLEGRO_BITMAP *bitmap;
 
       Actor2D(std::string identifier, ALLEGRO_BITMAP *bitmap);
+      ~Actor2D();
+
       // IMPORTANT
       void register_params();
       void render(double time);

--- a/include/allegro_flare/automation.h
+++ b/include/allegro_flare/automation.h
@@ -40,7 +40,10 @@ namespace automation
       std::string identifier;
       std::vector<Timeline::Track *> params;
 
+
       Actor(std::string identifier, actor_t type);
+      virtual ~Actor();
+
       Timeline::Track *get_param_by_id(const char *id);
 
       virtual void load_script(std::string script_filename);

--- a/include/allegro_flare/display.h
+++ b/include/allegro_flare/display.h
@@ -34,6 +34,7 @@ private:
 
 public:
    Display(int width, int height, int display_flags); // you must use AllegroFlare::create_display
+   virtual ~Display();
 
    ALLEGRO_DISPLAY *al_display;
    virtual void display_close_func();

--- a/include/allegro_flare/drawing_interface.h
+++ b/include/allegro_flare/drawing_interface.h
@@ -19,7 +19,7 @@ private:
 
 public:
 	DrawingInterface(std::string drawing_mode_name);
-	~DrawingInterface();
+	virtual ~DrawingInterface();
 	std::string get_mode_name();
 
 	// preparation and content

--- a/include/allegro_flare/gui/widgets/text_list.h
+++ b/include/allegro_flare/gui/widgets/text_list.h
@@ -20,6 +20,8 @@ protected:
 
 public:
    UIListItem();
+   virtual ~UIListItem();
+
    virtual vec2d draw_item(vec2d position) = 0; // returns the width/height of the item
 };
 

--- a/include/allegro_flare/gui/widgets/text_list.h
+++ b/include/allegro_flare/gui/widgets/text_list.h
@@ -36,6 +36,7 @@ public:
 
 public:
    UITextList(UIWidget *parent, float x, float y, float w);
+   virtual ~UITextList();
 
    void add_item(std::string item);
    void select_item(int index);

--- a/include/allegro_flare/json.h
+++ b/include/allegro_flare/json.h
@@ -21,6 +21,9 @@ namespace JSON
    class Value
    {
    public:
+      Value();
+      virtual ~Value();
+
       std::string value;
       virtual std::string toString(void);
 
@@ -35,6 +38,9 @@ namespace JSON
    class Object : public Value
    {
    public:
+      Object();
+      virtual ~Object();
+
       std::map<std::string, Value *> values;
 
       virtual std::string toString(void);
@@ -46,6 +52,9 @@ namespace JSON
    class Array : public Value
    {
    public:
+      Array();
+      virtual ~Array();
+
       std::vector<Value *> values;
       void push(Value *value);
 
@@ -56,6 +65,9 @@ namespace JSON
    class String : public Value
    {
    public:
+      String();
+      virtual ~String();
+
       virtual std::string toString(void);
       std::string stringValue() const;
    };

--- a/include/allegro_flare/object2d.h
+++ b/include/allegro_flare/object2d.h
@@ -48,6 +48,7 @@ public:
    ALLEGRO_COLOR color();
 
    object2d(float x, float y, float w, float h);
+   virtual ~object2d();
 
    virtual object2d &transform_on();
    virtual object2d &appearance_on();

--- a/include/allegro_flare/programming_language.h
+++ b/include/allegro_flare/programming_language.h
@@ -68,7 +68,11 @@ public:
 class InterpreterInterface
 {
 public:
+   InterpreterInterface();
+   virtual ~InterpreterInterface();
+
    VirtualMemory memory;
+
    virtual void interpret(std::string val) = 0;
 };
 

--- a/include/allegro_flare/screen.h
+++ b/include/allegro_flare/screen.h
@@ -85,7 +85,7 @@ public:
    void set_on_display(Display *display);
    static int get_num_screens();
    Screen(Display *display=nullptr);
-   ~Screen();
+   virtual ~Screen();
 };
 
 

--- a/include/allegro_flare/screens/simple_notification_screen.h
+++ b/include/allegro_flare/screens/simple_notification_screen.h
@@ -44,6 +44,8 @@ private:
 
 public:
    SimpleNotificationScreen(Display *display, ALLEGRO_FONT *font);
+   virtual ~SimpleNotificationScreen();
+
    void primary_timer_func() override;
    void spawn_notification(std::string text);
 };

--- a/src/automation/automation.cpp
+++ b/src/automation/automation.cpp
@@ -68,6 +68,13 @@ namespace automation
 
 
 
+   Actor::~Actor()
+   {
+   }
+
+
+
+
    Timeline::Track *Actor::get_param_by_id(const char *id)
    {
       for (unsigned i=0; i<params.size(); i++)

--- a/src/automation/automation.cpp
+++ b/src/automation/automation.cpp
@@ -128,6 +128,13 @@ namespace automation
 
 
 
+   Actor2D::~Actor2D()
+   {
+   }
+
+
+
+
    void Actor2D::register_params()
    {
       //std::cout << "Here";

--- a/src/encryption/sha2.cpp
+++ b/src/encryption/sha2.cpp
@@ -46,7 +46,11 @@
  
 class SHA2
 {
+
 public:
+    SHA2();
+    virtual ~SHA2();
+
     virtual void init() = 0;
     virtual void update(const unsigned char *message, unsigned int len) = 0;
     virtual void final(unsigned char *digest) = 0;

--- a/src/framework/display.cpp
+++ b/src/framework/display.cpp
@@ -40,6 +40,11 @@ Display::Display(int width, int height, int display_flags)
 
 
 
+Display::~Display()
+{
+}
+
+
 
 void Display::display_close_func()
 {

--- a/src/framework/gui/widgets/text_list.cpp
+++ b/src/framework/gui/widgets/text_list.cpp
@@ -17,6 +17,11 @@ UIListItem::UIListItem() {};
 
 
 
+UIListItem::~UIListItem() {};
+
+
+
+
 UITextList::UITextList(UIWidget *parent, float x, float y, float w)
    : UIWidget(parent, "UITextList", new UISurfaceAreaBox(x, y, w, 20))
    , item_padding(5)

--- a/src/framework/gui/widgets/text_list.cpp
+++ b/src/framework/gui/widgets/text_list.cpp
@@ -28,6 +28,12 @@ UITextList::UITextList(UIWidget *parent, float x, float y, float w)
 
 
 
+UITextList::~UITextList()
+{}
+
+
+
+
 void UITextList::add_item(std::string item)
 {
    // TODO: insert()

--- a/src/framework/screens/simple_notification_screen.cpp
+++ b/src/framework/screens/simple_notification_screen.cpp
@@ -34,6 +34,13 @@ SimpleNotificationScreen::SimpleNotification::SimpleNotification(std::string tex
 
 
 
+SimpleNotificationScreen::~SimpleNotificationScreen()
+{
+}
+
+
+
+
 void SimpleNotificationScreen::SimpleNotification::draw(float x_cursor, float y_cursor)
 {
    if (can_die) return;

--- a/src/graphics/object2d.cpp
+++ b/src/graphics/object2d.cpp
@@ -59,6 +59,13 @@ object2d::object2d(float x, float y, float w, float h)
 
 
 
+object2d::~object2d()
+{
+}
+
+
+
+
 object2d &object2d::transform_on()
 {
    if (!_placement)


### PR DESCRIPTION
When compiling [FullScore](https://github.com/MarkOates/fullscore) after updating `make`, a lot of warnings were thrown regarding:

```
warning: 'ClassName' has virtual functions but non-virtual destructor
```

where `ClassName` was a bunch of different classes matching that error.

These errors are thrown by the `-Wnon-virtual-dtor` flag and were not being resolved by allegro_flare.  This PR attempts adds the flag and fixes the warnings.