### PR TITLE
Add AllegroColorAttributeDatatype

### DIFF
--- a/include/allegro_flare/allegro_color_attribute_datatype.h
+++ b/include/allegro_flare/allegro_color_attribute_datatype.h
@@ -10,6 +10,8 @@
 struct AllegroColorAttributeDatatype
 {
 public:
+   static const std::string IDENTIFIER;
+
    ALLEGRO_COLOR color;
 
    static bool to_val_func(void *val, std::string str);

--- a/include/allegro_flare/allegro_color_attribute_datatype.h
+++ b/include/allegro_flare/allegro_color_attribute_datatype.h
@@ -1,0 +1,20 @@
+#pragma once
+
+
+
+#include <allegro5/allegro_color.h>
+#include <string>
+
+
+
+struct AllegroColorAttributeDatatype
+{
+public:
+   ALLEGRO_COLOR color;
+
+   static bool to_val_func(void *val, std::string str);
+   static std::string to_str_func(void *val);
+};
+
+
+

--- a/src/allegro_color_attribute_datatype.cpp
+++ b/src/allegro_color_attribute_datatype.cpp
@@ -1,0 +1,31 @@
+
+
+
+#include <allegro_flare/allegro_color_attribute_datatype.h>
+#include <sstream>
+
+
+
+bool AllegroColorAttributeDatatype::to_val_func(void *val, std::string str)
+{
+   AllegroColorAttributeDatatype &d = *static_cast<AllegroColorAttributeDatatype *>(val);
+   std::stringstream ss(str);
+   ss >> d.color.r;
+   ss >> d.color.g;
+   ss >> d.color.b;
+   ss >> d.color.a;
+   return true;
+}
+
+
+
+std::string AllegroColorAttributeDatatype::to_str_func(void *val)
+{
+   AllegroColorAttributeDatatype &d = *static_cast<AllegroColorAttributeDatatype *>(val);
+   std::stringstream ss;
+   ss << d.color.r << " " << d.color.g << " " << d.color.b << " " << d.color.a;
+   return ss.str();
+}
+
+
+

--- a/src/allegro_color_attribute_datatype.cpp
+++ b/src/allegro_color_attribute_datatype.cpp
@@ -29,3 +29,7 @@ std::string AllegroColorAttributeDatatype::to_str_func(void *val)
 
 
 
+const std::string AllegroColorAttributeDatatype::IDENTIFIER = "ALLEGRO_COLOR";
+
+
+

--- a/src/framework/framework.cpp
+++ b/src/framework/framework.cpp
@@ -10,6 +10,8 @@
 #include <allegro_flare/bins/font_bin.h>
 #include <allegro_flare/bins/model_bin.h>
 #include <allegro_flare/bins/sample_bin.h>
+#include <allegro_flare/allegro_color_attribute_datatype.h>
+#include <allegro_flare/attributes.h>
 #include <allegro_flare/motion.h>
 #include <allegro_flare/useful.h>
 #include <allegro_flare/version.h>
@@ -155,6 +157,12 @@ bool Framework::initialize(std::string config_filename)
    else std::cerr << "no joystick(s) detected" << std::endl;
 
    instance = new Framework(config_filename);
+
+   Attributes::create_datatype_definition(
+      AllegroColorAttributeDatatype::IDENTIFIER,
+      AllegroColorAttributeDatatype::to_val_func,
+      AllegroColorAttributeDatatype::to_str_func
+   );
 
    initialized = true;
 

--- a/tests/allegro_color_attribute_datatype_test.cpp
+++ b/tests/allegro_color_attribute_datatype_test.cpp
@@ -14,13 +14,13 @@
 
 BOOST_AUTO_TEST_CASE(allegro_color_custom_attribute_can_set_and_get_an_allegro_color)
 {
-   Attributes attributes;
-
-   attributes.create_datatype_definition(
+   Attributes::create_datatype_definition(
       AllegroColorAttributeDatatype::IDENTIFIER,
       AllegroColorAttributeDatatype::to_val_func,
       AllegroColorAttributeDatatype::to_str_func
    );
+
+   Attributes attributes;
 
    ALLEGRO_COLOR color_1 = al_map_rgba_f(0.123, 0.357, 0.876, 0.926);
    ALLEGRO_COLOR color_2 = al_map_rgb(0, 0, 0);

--- a/tests/allegro_color_attribute_datatype_test.cpp
+++ b/tests/allegro_color_attribute_datatype_test.cpp
@@ -1,0 +1,44 @@
+
+
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE AllegroColorAttributeDatatypeTestModule
+#include <boost/test/unit_test.hpp>
+
+
+
+#include <allegro_flare/attributes.h>
+#include <allegro_flare/allegro_color_attribute_datatype.h>
+
+
+
+BOOST_AUTO_TEST_CASE(allegro_color_custom_attribute_can_set_and_get_an_allegro_color)
+{
+   Attributes attributes;
+
+   attributes.create_datatype_definition(
+      AllegroColorAttributeDatatype::IDENTIFIER,
+      AllegroColorAttributeDatatype::to_val_func,
+      AllegroColorAttributeDatatype::to_str_func
+   );
+
+   ALLEGRO_COLOR color_1 = al_map_rgba_f(0.123, 0.357, 0.876, 0.926);
+   ALLEGRO_COLOR color_2 = al_map_rgb(0, 0, 0);
+
+   BOOST_CHECK_EQUAL(true, attributes.set("the_color", AllegroColorAttributeDatatype::IDENTIFIER, &color_1));
+   BOOST_CHECK_EQUAL(true, attributes.get_as_custom(&color_2, AllegroColorAttributeDatatype::IDENTIFIER, "the_color"));
+   BOOST_CHECK_CLOSE(0.123, color_2.r, 0.0001);
+   BOOST_CHECK_CLOSE(0.357, color_2.g, 0.0001);
+   BOOST_CHECK_CLOSE(0.876, color_2.b, 0.0001);
+   BOOST_CHECK_CLOSE(0.926, color_2.a, 0.0001);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(allegro_color_custom_attribute_has_the_expected_identifier)
+{
+   BOOST_CHECK_EQUAL("ALLEGRO_COLOR", AllegroColorAttributeDatatype::IDENTIFIER);
+}
+
+
+

--- a/tests/framework_test.cpp
+++ b/tests/framework_test.cpp
@@ -1,0 +1,9 @@
+
+
+
+// TODO
+
+// test that AllegroColorAttributeDatatype definition is included in Attributes
+
+
+


### PR DESCRIPTION
## Custom Attributes

One of the great features of AllegroFlare is the `Attributes` class.  It's flexible and is better tested than any other component in the library.  It's standalone and doesn't need Allegro (or any other library) as a dependency.

However, there is no support for `ALLEGRO_COLOR` as a datatype.  Rather than including it as a native type in `Attributes` (and tainting the dependency-free class), we should create a custom datatype definition, so it can be set and retrieved as an attribute.  Since the attribute will be used quite a bit in AllegroFlare, it wouldn't hurt to include the definition implicitly with `Framework`.