### PR TITLE
Add KeyboardCommandMapper

### DIFF
--- a/include/allegro_flare/keyboard_command_mapper.h
+++ b/include/allegro_flare/keyboard_command_mapper.h
@@ -1,0 +1,25 @@
+#pragma once
+
+
+
+#include <map>
+#include <string>
+#include <tuple>
+
+
+
+class KeyboardCommandMapper
+{
+private:
+   std::map<std::tuple<int, bool, bool, bool>, std::string> mapping;
+
+public:
+   KeyboardCommandMapper();
+   ~KeyboardCommandMapper();
+
+   bool set_mapping(int al_keycode, bool shift, bool ctrl, bool alt, std::string comand_identifier);
+   std::string get_mapping(int al_keycode, bool shift, bool ctrl, bool alt);
+};
+
+
+

--- a/src/keyboard_command_mapper.cpp
+++ b/src/keyboard_command_mapper.cpp
@@ -1,0 +1,37 @@
+
+
+
+#include <allegro_flare/keyboard_command_mapper.h>
+
+
+
+KeyboardCommandMapper::KeyboardCommandMapper()
+{}
+
+
+
+KeyboardCommandMapper::~KeyboardCommandMapper()
+{}
+
+
+
+bool KeyboardCommandMapper::set_mapping(int al_keycode, bool shift, bool ctrl, bool alt, std::string command_identifier)
+{
+   mapping[std::tuple<int, bool, bool, bool>(al_keycode, shift, ctrl, alt)] = command_identifier;
+   return true;
+}
+
+
+
+std::string KeyboardCommandMapper::get_mapping(int al_keycode, bool shift, bool ctrl, bool alt)
+{
+   std::map<std::tuple<int, bool, bool, bool>, std::string>::iterator mapper_iterator
+      = mapping.find(std::tuple<int, bool, bool, bool>(al_keycode, shift, ctrl, alt));
+
+   if (mapper_iterator == mapping.end()) return std::string();
+
+   return (*mapper_iterator).second;
+}
+
+
+

--- a/tests/keyboard_command_mapper_test.cpp
+++ b/tests/keyboard_command_mapper_test.cpp
@@ -1,0 +1,61 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/components/keyboard_command_mapper.h>
+
+
+
+TEST(KeyboardCommandMapperTest, can_get_and_set_mappings)
+{
+   KeyboardCommandMapper mapper;
+
+   std::string command_identifier_1 = "this_is_the_command";
+
+   EXPECT_TRUE(mapper.set_mapping(14 /*ALLEGRO_KEY_N*/, true, false, true, command_identifier_1));
+   EXPECT_EQ(command_identifier_1, mapper.get_mapping(14 /*ALLEGRO_KEY_N*/, true, false, true));
+}
+
+
+
+TEST(KeyboardCommandMapperTest, can_get_and_set_all_valid_allegro_keycodes)
+{
+   KeyboardCommandMapper mapper;
+
+   for (unsigned k=0 /*ALLEGRO_KEY_A*/; k<215/*ALLEGRO_KEY_MODIFIERS*/; k++)
+   {
+      std::string identifier = "this is a test identifier";
+
+      EXPECT_TRUE(          mapper.set_mapping(k, true, true, true, identifier));
+      EXPECT_EQ(identifier, mapper.get_mapping(k, true, true, true));
+
+      EXPECT_TRUE(          mapper.set_mapping(k, true, false, true, identifier));
+      EXPECT_EQ(identifier, mapper.get_mapping(k, true, false, true));
+
+      EXPECT_TRUE(          mapper.set_mapping(k, true, true, false, identifier));
+      EXPECT_EQ(identifier, mapper.get_mapping(k, true, true, false));
+   }
+}
+
+
+
+TEST(KeyboardCommandMapperTest, returns_an_empty_string_if_identifier_is_not_found)
+{
+   KeyboardCommandMapper mapper;
+
+   EXPECT_EQ("", mapper.get_mapping(16, true, false, false));
+   EXPECT_EQ("", mapper.get_mapping(24, false, true, false));
+   EXPECT_EQ("", mapper.get_mapping(0, false, false, true));
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
## Keyboard Command Mapper

It's very common to want to map particular keyboard combinations (<kbd>Ctrl</kbd>, <kbd>Alt</kbd>, <kbd>Shift</kbd>, etc...) to commands.  This simple `KeyboardCommandMapper` class allows mapping a combination to a string identifier.

The interface is simple:

## `KeyboardCommandMapper` Instance Functions:

### set_mapping
```
bool set_mapping(int al_keycode, bool shift, bool ctrl, bool alt, std::string comand_identifier)
```
Associates a keyboard combination to a string identifier.  If one already exists, is overwritten.  Always returns `true`.

### get_mapping
```
std::string get_mapping(int al_keycode, bool shift, bool ctrl, bool alt)
```
Returns the string identifier matching a keyboard combination.  If none is present, returns an empty string.
