### PR TITLE
Allow compound keyboard command mapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ LIBS_ROOT=/Users/markoates/Repos
 ALLEGRO_DIR=$(LIBS_ROOT)/allegro5
 ALLEGRO_LIB_DIR=$(LIBS_ROOT)/allegro5/build/lib
 ALLEGROFLARE_DIR=$(LIBS_ROOT)/allegro_flare
+GOOGLE_TEST_DIR=$(LIBS_ROOT)/googletest
+GOOGLE_TEST_LIB_DIR=$(GOOGLE_TEST_DIR)/build/googlemock/gtest
+GOOGLE_TEST_INCLUDE_DIR=$(GOOGLE_TEST_DIR)/googletest/include
 
 
 
@@ -131,13 +134,13 @@ TESTS=$(wildcard tests/*.cpp)
 TEST_OBJS=$(TESTS:tests/%.cpp=bin/tests/%$(BINARY_EXTENSION))
 
 ALLEGRO_TEST_LIBS=-lallegro_color -lallegro_font -lallegro_ttf -lallegro_dialog -lallegro_audio -lallegro_acodec -lallegro_primitives -lallegro_image -lallegro
+GOOGLE_TEST_LIB=-lgtest
 
 tests: $(TEST_OBJS)
 
 bin/tests/%$(BINARY_EXTENSION): tests/%.cpp lib/lib$(ALLEGROFLARE_LIB_NAME).a
 	@echo "compiling $< -> $@"
-	@g++ -std=gnu++11 $< -o $@ -I$(ALLEGROFLARE_DIR)/include -I$(ALLEGRO_DIR)/include -L$(ALLEGROFLARE_DIR)/lib -l$(ALLEGROFLARE_LIB_NAME) -L$(ALLEGRO_LIB_DIR) $(ALLEGRO_TEST_LIBS) -lboost_unit_test_framework -lcurl
-
+	@g++ -std=gnu++11 $< -o $@ -I$(ALLEGROFLARE_DIR)/include -I$(ALLEGRO_DIR)/include -I$(GOOGLE_TEST_INCLUDE_DIR) -L$(ALLEGROFLARE_DIR)/lib -l$(ALLEGROFLARE_LIB_NAME) -L$(ALLEGRO_LIB_DIR) -L$(GOOGLE_TEST_LIB_DIR) $(ALLEGRO_TEST_LIBS) -lboost_unit_test_framework -lcurl $(GOOGLE_TEST_LIB)
 
 
 

--- a/include/allegro_flare/keyboard_command_mapper.h
+++ b/include/allegro_flare/keyboard_command_mapper.h
@@ -5,20 +5,21 @@
 #include <map>
 #include <string>
 #include <tuple>
+#include <vector>
 
 
 
 class KeyboardCommandMapper
 {
 private:
-   std::map<std::tuple<int, bool, bool, bool>, std::string> mapping;
+   std::map<std::tuple<int, bool, bool, bool>, std::vector<std::string>> mapping;
 
 public:
    KeyboardCommandMapper();
    ~KeyboardCommandMapper();
 
-   bool set_mapping(int al_keycode, bool shift, bool ctrl, bool alt, std::string comand_identifier);
-   std::string get_mapping(int al_keycode, bool shift, bool ctrl, bool alt);
+   bool set_mapping(int al_keycode, bool shift, bool ctrl, bool alt, std::vector<std::string> comand_identifier);
+   std::vector<std::string> get_mapping(int al_keycode, bool shift, bool ctrl, bool alt);
 };
 
 

--- a/src/keyboard_command_mapper.cpp
+++ b/src/keyboard_command_mapper.cpp
@@ -15,20 +15,20 @@ KeyboardCommandMapper::~KeyboardCommandMapper()
 
 
 
-bool KeyboardCommandMapper::set_mapping(int al_keycode, bool shift, bool ctrl, bool alt, std::string command_identifier)
+bool KeyboardCommandMapper::set_mapping(int al_keycode, bool shift, bool ctrl, bool alt, std::vector<std::string> command_identifiers)
 {
-   mapping[std::tuple<int, bool, bool, bool>(al_keycode, shift, ctrl, alt)] = command_identifier;
+   mapping[std::tuple<int, bool, bool, bool>(al_keycode, shift, ctrl, alt)] = command_identifiers;
    return true;
 }
 
 
 
-std::string KeyboardCommandMapper::get_mapping(int al_keycode, bool shift, bool ctrl, bool alt)
+std::vector<std::string> KeyboardCommandMapper::get_mapping(int al_keycode, bool shift, bool ctrl, bool alt)
 {
-   std::map<std::tuple<int, bool, bool, bool>, std::string>::iterator mapper_iterator
+   std::map<std::tuple<int, bool, bool, bool>, std::vector<std::string>>::iterator mapper_iterator
       = mapping.find(std::tuple<int, bool, bool, bool>(al_keycode, shift, ctrl, alt));
 
-   if (mapper_iterator == mapping.end()) return std::string();
+   if (mapper_iterator == mapping.end()) return {};
 
    return (*mapper_iterator).second;
 }

--- a/tests/keyboard_command_mapper_test.cpp
+++ b/tests/keyboard_command_mapper_test.cpp
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-#include <fullscore/components/keyboard_command_mapper.h>
+#include <allegro_flare/keyboard_command_mapper.h>
 
 
 
@@ -11,10 +11,10 @@ TEST(KeyboardCommandMapperTest, can_get_and_set_mappings)
 {
    KeyboardCommandMapper mapper;
 
-   std::string command_identifier_1 = "this_is_the_command";
+   std::vector<std::string> command_identifiers = {"this_is_the_command"};
 
-   EXPECT_TRUE(mapper.set_mapping(14 /*ALLEGRO_KEY_N*/, true, false, true, command_identifier_1));
-   EXPECT_EQ(command_identifier_1, mapper.get_mapping(14 /*ALLEGRO_KEY_N*/, true, false, true));
+   EXPECT_TRUE(mapper.set_mapping(14 /*ALLEGRO_KEY_N*/, true, false, true, command_identifiers));
+   EXPECT_EQ(command_identifiers, mapper.get_mapping(14 /*ALLEGRO_KEY_N*/, true, false, true));
 }
 
 
@@ -25,28 +25,29 @@ TEST(KeyboardCommandMapperTest, can_get_and_set_all_valid_allegro_keycodes)
 
    for (unsigned k=0 /*ALLEGRO_KEY_A*/; k<215/*ALLEGRO_KEY_MODIFIERS*/; k++)
    {
-      std::string identifier = "this is a test identifier";
+      std::vector<std::string> mapped_command_identifiers = {"this is a test identifier"};
 
-      EXPECT_TRUE(          mapper.set_mapping(k, true, true, true, identifier));
-      EXPECT_EQ(identifier, mapper.get_mapping(k, true, true, true));
+      EXPECT_TRUE(                          mapper.set_mapping(k, true, true, true, mapped_command_identifiers));
+      EXPECT_EQ(mapped_command_identifiers, mapper.get_mapping(k, true, true, true));
 
-      EXPECT_TRUE(          mapper.set_mapping(k, true, false, true, identifier));
-      EXPECT_EQ(identifier, mapper.get_mapping(k, true, false, true));
+      EXPECT_TRUE(                          mapper.set_mapping(k, true, false, true, mapped_command_identifiers));
+      EXPECT_EQ(mapped_command_identifiers, mapper.get_mapping(k, true, false, true));
 
-      EXPECT_TRUE(          mapper.set_mapping(k, true, true, false, identifier));
-      EXPECT_EQ(identifier, mapper.get_mapping(k, true, true, false));
+      EXPECT_TRUE(                          mapper.set_mapping(k, true, true, false, mapped_command_identifiers));
+      EXPECT_EQ(mapped_command_identifiers, mapper.get_mapping(k, true, true, false));
    }
 }
 
 
 
-TEST(KeyboardCommandMapperTest, returns_an_empty_string_if_identifier_is_not_found)
+TEST(KeyboardCommandMapperTest, returns_an_empty_vector_if_identifier_is_not_found)
 {
    KeyboardCommandMapper mapper;
+   std::vector<std::string> expected_return_value = {};
 
-   EXPECT_EQ("", mapper.get_mapping(16, true, false, false));
-   EXPECT_EQ("", mapper.get_mapping(24, false, true, false));
-   EXPECT_EQ("", mapper.get_mapping(0, false, false, true));
+   EXPECT_EQ(expected_return_value, mapper.get_mapping(16, true, false, false));
+   EXPECT_EQ(expected_return_value, mapper.get_mapping(24, false, true, false));
+   EXPECT_EQ(expected_return_value, mapper.get_mapping(0, false, false, true));
 }
 
 


### PR DESCRIPTION
`KeyboardCommandMapper` maps keyboard combinations so a single string.  Now, allow mapper to set to an array of strings, allowing for multiple commands to be compacted in the mapper.

Also, some changes to the `Makefile` allowing for Gtest files to finally be compiled.